### PR TITLE
Fixed Amazon Login after Amazon account e-mail change

### DIFF
--- a/app/code/community/Amazon/Login/Model/Customer.php
+++ b/app/code/community/Amazon/Login/Model/Customer.php
@@ -25,8 +25,13 @@ class Amazon_Login_Model_Customer extends Mage_Customer_Model_Customer
             // Load Amazon Login association
             $row = Mage::getModel('amazon_login/login')->load($amazonProfile['user_id'], 'amazon_uid');
             
-            // Load customer by ID
-            $this->setWebsiteId(Mage::app()->getWebsite()->getId())->load($row->getCustomerId());
+            if ($row->getLoginId()) {
+                // Load customer by id
+                $this->setWebsiteId(Mage::app()->getWebsite()->getId())->load($row->getCustomerId());
+            } else {
+                // Load customer by email
+                $this->setWebsiteId(Mage::app()->getWebsite()->getId())->loadByEmail($amazonProfile['email']);
+            }
 
             // If Magento customer account exists and there is no association, then the Magento account
             // must be verified, as Amazon does not verify email addresses.

--- a/app/code/community/Amazon/Login/Model/Customer.php
+++ b/app/code/community/Amazon/Login/Model/Customer.php
@@ -21,7 +21,7 @@ class Amazon_Login_Model_Customer extends Mage_Customer_Model_Customer
     {
         $amazonProfile = $this->getAmazonProfile($token);
 
-        if ($amazonProfile && isset($amazonProfile['email'])) {
+        if ($amazonProfile && isset($amazonProfile['user_id']) && isset($amazonProfile['email'])) {
             // Load Amazon Login association
             $row = Mage::getModel('amazon_login/login')->load($amazonProfile['user_id'], 'amazon_uid');
             

--- a/app/code/community/Amazon/Login/Model/Customer.php
+++ b/app/code/community/Amazon/Login/Model/Customer.php
@@ -22,12 +22,11 @@ class Amazon_Login_Model_Customer extends Mage_Customer_Model_Customer
         $amazonProfile = $this->getAmazonProfile($token);
 
         if ($amazonProfile && isset($amazonProfile['email'])) {
-
-            // Load customer by email
-            $this->setWebsiteId(Mage::app()->getWebsite()->getId())->loadByEmail($amazonProfile['email']);
-
             // Load Amazon Login association
             $row = Mage::getModel('amazon_login/login')->load($amazonProfile['user_id'], 'amazon_uid');
+            
+            // Load customer by ID
+            $this->setWebsiteId(Mage::app()->getWebsite()->getId())->load($row->getCustomerId());
 
             // If Magento customer account exists and there is no association, then the Magento account
             // must be verified, as Amazon does not verify email addresses.


### PR DESCRIPTION
Amazon and Magento accounts should be compared using Amazon UID, not e-mail, because if you change Amazon account e-mail it creates new Magento customer.