### PR TITLE
Truncate 9 digit postal code to 5 digits.

### DIFF
--- a/app/code/community/Amazon/Payments/Controller/Checkout.php
+++ b/app/code/community/Amazon/Payments/Controller/Checkout.php
@@ -198,13 +198,19 @@ abstract class Amazon_Payments_Controller_Checkout extends Mage_Checkout_Control
             $regionModel = Mage::getModel('directory/region')->loadByCode($address->getStateOrRegion(), $address->getCountryCode());
             $regionId    = $regionModel->getId();
 
+            /* Get postal code and strip +4 (if exists) since Magento only deals with 5 digits. */
+            $postalCode = $address->getPostalCode();
+            if (strlen($postalCode) >= 5) {
+                $postalCode = substr($postalCode, 0, 5);
+            }
+
             $data = array(
                 'firstname'   => $firstName,
                 'lastname'    => $lastName,
                 'street'      => array($address->getAddressLine1(), $address->getAddressLine2()),
                 'city'        => $address->getCity(),
                 'region_id'   => $regionId,
-                'postcode'    => $address->getPostalCode(),
+                'postcode'    => $postalCode,
                 'country_id'  => $address->getCountryCode(),
                 'telephone'   => ($address->getPhone()) ? $address->getPhone() : '-', // Mage requires phone number
                 'use_for_shipping' => true,


### PR DESCRIPTION
Sometimes a 9 digit postal code will get returned. This change will check if the
+4 exists and remove it. Magento assumes 5 digit postal codes. 9 digit postal
codes will also break some shipping calculators.