### PR TITLE
Update Api.php

### DIFF
--- a/app/code/community/Amazon/Payments/Model/Api.php
+++ b/app/code/community/Amazon/Payments/Model/Api.php
@@ -38,7 +38,7 @@ class Amazon_Payments_Model_Api
                 'region'             => $this->getConfig()->getRegion(),
                 'environment'        => ($this->getConfig()->isSandbox()) ? 'sandbox' : 'live',
                 'applicationName'    => 'Amazon Payments Magento Extension',
-                'applicationVersion' => current(Mage::getConfig()->getNode('modules/Amazon_Payments/version')),
+                'applicationVersion' => (string) Mage::getConfig()->getNode('modules/Amazon_Payments/version'),
                 'serviceURL'         => '',
                 'widgetURL'          => '',
                 'caBundleFile'       => '',


### PR DESCRIPTION
This code breaks with HHVM because current() does not behave the same way as PHP. The Mage_Core_Model_Config_Element Object is essentially a SimpleXML object, which is traversable, but not an Array.  The current() function states it works on arrays, not traversable objects.  To address this we can cast the node to a string, which is a common practice throughout magento's codebase.