### PR TITLE
Use getTableName() so it works with prefixes

### DIFF
--- a/app/code/community/Amazon/Payments/sql/payments_setup/upgrade-1.3.0-1.4.0.php
+++ b/app/code/community/Amazon/Payments/sql/payments_setup/upgrade-1.3.0-1.4.0.php
@@ -17,11 +17,11 @@ $db = $installer->getConnection();
 
 // Encrypt keys
 $select = $db->select()
-    ->from('core_config_data')
+    ->from(Mage::getSingleton('core/resource')->getTableName('core_config_data'))
     ->where('path IN (?)', array('payment/amazon_payments/access_secret', 'payment/amazon_payments/client_secret'));
 
 foreach ($db->fetchAll($select) as $row) {
-    $db->update('core_config_data', array('value' => Mage::helper('core')->encrypt(trim($row['value']))), 'config_id=' . $row['config_id']);
+    $db->update(Mage::getSingleton('core/resource')->getTableName('core_config_data'), array('value' => Mage::helper('core')->encrypt(trim($row['value']))), 'config_id=' . $row['config_id']);
 }
 
 $installer->endSetup();


### PR DESCRIPTION
Installs that use a table prefix like "mage_" do not work with the current code. It produces the following error...

SQLSTATE[42S02]: Base table or view not found: 1146 Table 'core_config_data' doesn't exist