### PR TITLE
PHP7 Compatibility Fix

### DIFF
--- a/lib/MarketplaceWebServiceSellers/Model/ResponseHeaderMetaData.php
+++ b/lib/MarketplaceWebServiceSellers/Model/ResponseHeaderMetaData.php
@@ -29,12 +29,12 @@ class MarketplaceWebServiceSellers_Model_ResponseHeaderMetadata {
   private $metadata = array();
 
   public function __construct($requestId = null, $responseContext = null, $timestamp = null,
-                              $quotaMax = null, $quotaMax = null, $quotaResetsAt = null) {
+                              $quotaMax = null, $quotaRemaining = null, $quotaResetsAt = null) {
     $this->metadata[self::REQUEST_ID] = $requestId;
     $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
     $this->metadata[self::TIMESTAMP] = $timestamp;
     $this->metadata[self::QUOTA_MAX] = $quotaMax;
-    $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+    $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
     $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
   }
 


### PR DESCRIPTION
When trying to save the payment settings in Magento with PHP7, we get a PHP error because identical parameter names are no longer supported.

I've tried this fix locally and saw no problems, and I'm not sure if this was a typo or intentional.