### PR TITLE
Swap email localisation files to correct folders

### DIFF
--- a/app/locale/en_GB/template/email/amazon_payments_async_decline_hard.html
+++ b/app/locale/en_GB/template/email/amazon_payments_async_decline_hard.html
@@ -1,0 +1,39 @@
+<!--@subject Please contact us about your order @-->
+<!--@vars
+{"store url=\"\"":"Store Url",
+"var logo_url":"Email Logo Image Url",
+"htmlescape var=$customer.name":"Customer Name",
+"var order url":"Order details URL"}
+@-->
+
+<!--@styles
+body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif; }
+@-->
+
+<body style="background:#F6F6F6; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:12px; margin:0; padding:0;">
+<div style="background:#F6F6F6; font-family:Verdana, Arial, Helvetica, sans-serif; font-size:12px; margin:0; padding:0;">
+<table cellspacing="0" cellpadding="0" border="0" height="100%" width="100%">
+        <tr>
+            <td align="center" valign="top" style="padding:20px 0 20px 0">
+                <!-- [ header starts here] -->
+                <table bgcolor="FFFFFF" cellspacing="0" cellpadding="10" border="0" width="650" style="border:1px solid #E0E0E0;">
+                    <tr>
+                        <td valign="top">
+                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0"/></a></td>
+                    </tr>
+                <!-- [ middle starts here] -->
+                    <tr>
+                        <td valign="top">
+                            <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;"">Dear {{htmlescape var=$customer.name}},</h1>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Unfortunately Amazon Payments declined the payment for your order in our online shop {{var store.name}}. Please contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or by phone at {{config path='general/store_information/phone'}}.</p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Thank you again, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</div>
+</body>

--- a/app/locale/en_GB/template/email/amazon_payments_async_decline_soft.html
+++ b/app/locale/en_GB/template/email/amazon_payments_async_decline_soft.html
@@ -19,20 +19,20 @@ body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif;
                 <table bgcolor="FFFFFF" cellspacing="0" cellpadding="10" border="0" width="650" style="border:1px solid #E0E0E0;">
                     <tr>
                         <td valign="top">
-                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0" /></a></td>
+                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0"/></a></td>
                     </tr>
                 <!-- [ middle starts here] -->
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;"">Dear {{htmlescape var=$customer.name}},</h1>
-                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments non pu&ograve; elaborare il suo pagamento. Visiti la pagina dei dettagli dell'ordine usando il link qui sotto e aggiorni il metodo di pagamento:</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments could not process your payment. Please visit your order details page below and update your payment method:</p>
                             <p style="font-size:12px; line-height:16px; margin:1.5em; margin-right:0;"><a href="{{var order_url}}">{{var order_url}}</a></p>
 
-                            <p style="font-size:12px; line-height:16px; margin:0;">In caso di dubbi o domande sul suo conto o su qualsiasi altro argomento, non esiti a contattarci all'indirizzo <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> o al numero {{config path='general/store_information/phone'}}.</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">If you have any questions about your account or any other matter, please feel free to contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or by phone at {{config path='general/store_information/phone'}}.</p>
                         </td>
                     </tr>
                     <tr>
-                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Grazie, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
+                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Thank you again, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
                     </tr>
                 </table>
             </td>

--- a/app/locale/en_US/template/email/amazon_payments_async_decline_soft.html
+++ b/app/locale/en_US/template/email/amazon_payments_async_decline_soft.html
@@ -19,20 +19,20 @@ body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif;
                 <table bgcolor="FFFFFF" cellspacing="0" cellpadding="10" border="0" width="650" style="border:1px solid #E0E0E0;">
                     <tr>
                         <td valign="top">
-                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0" /></a></td>
+                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0"/></a></td>
                     </tr>
                 <!-- [ middle starts here] -->
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;"">Dear {{htmlescape var=$customer.name}},</h1>
-                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments n'a pas pu traiter votre paiement. Consultez les d&eacute;tails de votre commande ci-dessous et mettez &agrave; jour votre mode de paiement&nbsp;:</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments could not process your payment. Please visit your order details page below and update your payment method:</p>
                             <p style="font-size:12px; line-height:16px; margin:1.5em; margin-right:0;"><a href="{{var order_url}}">{{var order_url}}</a></p>
 
-                            <p style="font-size:12px; line-height:16px; margin:0;">Pour toute question concernant votre compte ou tout autre sujet, n'h&eacute;sitez pas &agrave; nous contacter &agrave; l'adresse <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> ou par t&eacute;l&eacute;phone au {{config path='general/store_information/phone'}}.</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">If you have any questions about your account or any other matter, please feel free to contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or by phone at {{config path='general/store_information/phone'}}.</p>
                         </td>
                     </tr>
                     <tr>
-                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Merci encore, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
+                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Thank you again, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
                     </tr>
                 </table>
             </td>

--- a/app/locale/fr_FR/template/email/amazon_payments_async_decline_soft.html
+++ b/app/locale/fr_FR/template/email/amazon_payments_async_decline_soft.html
@@ -19,20 +19,20 @@ body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif;
                 <table bgcolor="FFFFFF" cellspacing="0" cellpadding="10" border="0" width="650" style="border:1px solid #E0E0E0;">
                     <tr>
                         <td valign="top">
-                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0"/></a></td>
+                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0" /></a></td>
                     </tr>
                 <!-- [ middle starts here] -->
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;"">Dear {{htmlescape var=$customer.name}},</h1>
-                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments could not process your payment. Please visit your order details page below and update your payment method:</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments n'a pas pu traiter votre paiement. Consultez les d&eacute;tails de votre commande ci-dessous et mettez &agrave; jour votre mode de paiement&nbsp;:</p>
                             <p style="font-size:12px; line-height:16px; margin:1.5em; margin-right:0;"><a href="{{var order_url}}">{{var order_url}}</a></p>
 
-                            <p style="font-size:12px; line-height:16px; margin:0;">If you have any questions about your account or any other matter, please feel free to contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or by phone at {{config path='general/store_information/phone'}}.</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Pour toute question concernant votre compte ou tout autre sujet, n'h&eacute;sitez pas &agrave; nous contacter &agrave; l'adresse <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> ou par t&eacute;l&eacute;phone au {{config path='general/store_information/phone'}}.</p>
                         </td>
                     </tr>
                     <tr>
-                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Thank you again, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
+                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Merci encore, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
                     </tr>
                 </table>
             </td>

--- a/app/locale/it_IT/template/email/amazon_payments_async_decline_soft.html
+++ b/app/locale/it_IT/template/email/amazon_payments_async_decline_soft.html
@@ -19,20 +19,20 @@ body,td { color:#2f2f2f; font:11px/1.35em Verdana, Arial, Helvetica, sans-serif;
                 <table bgcolor="FFFFFF" cellspacing="0" cellpadding="10" border="0" width="650" style="border:1px solid #E0E0E0;">
                     <tr>
                         <td valign="top">
-                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0"/></a></td>
+                            <a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{var logo_alt}}" style="margin-bottom:10px;" border="0" /></a></td>
                     </tr>
                 <!-- [ middle starts here] -->
                     <tr>
                         <td valign="top">
                             <h1 style="font-size:22px; font-weight:normal; line-height:22px; margin:0 0 11px 0;"">Dear {{htmlescape var=$customer.name}},</h1>
-                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments could not process your payment. Please visit your order details page below and update your payment method:</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">Amazon Payments non pu&ograve; elaborare il suo pagamento. Visiti la pagina dei dettagli dell'ordine usando il link qui sotto e aggiorni il metodo di pagamento:</p>
                             <p style="font-size:12px; line-height:16px; margin:1.5em; margin-right:0;"><a href="{{var order_url}}">{{var order_url}}</a></p>
 
-                            <p style="font-size:12px; line-height:16px; margin:0;">If you have any questions about your account or any other matter, please feel free to contact us at <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> or by phone at {{config path='general/store_information/phone'}}.</p>
+                            <p style="font-size:12px; line-height:16px; margin:0;">In caso di dubbi o domande sul suo conto o su qualsiasi altro argomento, non esiti a contattarci all'indirizzo <a href="mailto:{{config path='trans_email/ident_support/email'}}" style="color:#1E7EC8;">{{config path='trans_email/ident_support/email'}}</a> o al numero {{config path='general/store_information/phone'}}.</p>
                         </td>
                     </tr>
                     <tr>
-                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Thank you again, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
+                        <td bgcolor="#EAEAEA" align="center" style="background:#EAEAEA; text-align:center;"><center><p style="font-size:12px; margin:0;">Grazie, <strong>{{var store.getFrontendName()}}</strong></p></center></td>
                     </tr>
                 </table>
             </td>


### PR DESCRIPTION
Some of the soft decline email template locale files had got in the wrong folders swapped them about.
The hard decline template for the en_GB was missing so this copies the en_US one across to the en_GB
