### PR TITLE
Fixed compatibility issue with PHP 5.6

### DIFF
--- a/lib/OffAmazonPaymentsService/Client.php
+++ b/lib/OffAmazonPaymentsService/Client.php
@@ -117,9 +117,15 @@ class OffAmazonPaymentsService_Client implements OffAmazonPaymentsService_Interf
      */
     public function __construct($config = null)
     {
-        iconv_set_encoding('output_encoding', 'UTF-8');
-        iconv_set_encoding('input_encoding', 'UTF-8');
-        iconv_set_encoding('internal_encoding', 'UTF-8');
+        if (PHP_VERSION_ID < 50600) {
+            iconv_set_encoding('output_encoding', 'UTF-8');
+            iconv_set_encoding('input_encoding', 'UTF-8');
+            iconv_set_encoding('internal_encoding', 'UTF-8');
+        } else {
+            ini_set('output_encoding', 'UTF-8');
+            ini_set('input_encoding', 'UTF-8');
+            ini_set('default_charset', 'UTF-8');
+        }
 
         if ($config != null) {
             $this->_checkConfigHasAllRequiredKeys($config);


### PR DESCRIPTION
`lib/OffAmazonPaymentsService/Client.php` has compatibility issue with PHP 5.6 which can block checkout place order functionality when certain conditions are met. This Pull Request fixes this problem using method already in use in `lib/MarketplaceWebServiceSellers/KeycheckClient.php` and `lib/MarketplaceWebServiceSellers/Client.php.