### PR TITLE
AJAX post-load callback fix

### DIFF
--- a/app/design/frontend/base/default/template/amazon_payments/button.phtml
+++ b/app/design/frontend/base/default/template/amazon_payments/button.phtml
@@ -51,6 +51,10 @@
         OffAmazonPayments.Button("<?php echo $this->getAmazonPayButtonId(); ?>", "<?php echo $this->getSellerId(); ?>", AmazonButtonOptions);
 
     }
+
+    if (typeof OffAmazonPayments !== 'undefined' && OffAmazonPayments.INITIALIZED) {
+        onAmazonPaymentsReady();
+    }
   </script>
 
 <?php endif; ?>


### PR DESCRIPTION
Since the Amazon radio was added to the checkout payment step, this process often fails due to the reliance on the AmazonPaymentsCallbacks array.

By the time a user typically makes it to the payment step, the Amazon code has already been loaded and initialized. Thus, when the callback is added by the AJAX payment block, these callbacks are no longer processed.

In order to fix this (and allow the button to be rendered and then triggered by the onclick event), we need to detect whether Amazon was loaded and manually trigger the processor.

This issue is referenced in #304.