### PR TITLE
AMAZON-55: Unify usage of getAmazonName method

### DIFF
--- a/app/code/community/Amazon/Payments/Helper/Data.php
+++ b/app/code/community/Amazon/Payments/Helper/Data.php
@@ -342,10 +342,7 @@ class Amazon_Payments_Helper_Data extends Mage_Core_Helper_Abstract
      * @param OffAmazonPaymentsService_Model_Address amazonAddress
      */
     public function transformAmazonAddressToMagentoAddress($amazonAddress) {
-        $name = $amazonAddress->getName();
-        $firstName = substr($name, 0, strrpos($name, ' '));
-        $lastName  = substr($name, strlen($firstName) + 1);
-
+        list($firstName, $lastName) = self::getAmazonName($amazonAddress->getName());
         $data['firstname'] = $firstName;
         $data['lastname'] = $lastName;
         $data['country_id'] = $amazonAddress->getCountryCode();
@@ -401,4 +398,21 @@ class Amazon_Payments_Helper_Data extends Mage_Core_Helper_Abstract
       }
     }
 
+    /**
+     * Get Amazon Name
+     *
+     * @return array
+     */
+    public static function getAmazonName($name)
+    {
+        // if the user only has a first name, handle accordingly
+        $trimmedName = trim($name);
+        if(strpos($trimmedName,' ')===false) {
+            return array($trimmedName,'.');
+        }
+
+        $firstName = substr($name, 0, strrpos($name, ' '));
+        $lastName  = substr($name, strlen($firstName) + 1);
+        return array($firstName, $lastName);
+    }
 }

--- a/app/code/community/Amazon/Payments/Model/Customer.php
+++ b/app/code/community/Amazon/Payments/Model/Customer.php
@@ -79,24 +79,6 @@ class Amazon_Payments_Model_Customer extends Mage_Customer_Model_Customer
     }
 
     /**
-     * Get Amazon Name
-     *
-     * @return array
-     */
-    public function getAmazonName($name)
-    {
-        // if the user only has a first name, handle accordingly
-        $trimmedName = trim($name);
-        if(strpos($trimmedName,' ')===false) {
-            return array($trimmedName,'.');
-        }
-
-        $firstName = substr($name, 0, strrpos($name, ' '));
-        $lastName  = substr($name, strlen($firstName) + 1);
-        return array($firstName, $lastName);
-    }
-
-    /**
      * Create a new customer
      *
      * @param array $amazonProfile
@@ -105,7 +87,7 @@ class Amazon_Payments_Model_Customer extends Mage_Customer_Model_Customer
      */
     public function createCustomer($amazonProfile)
     {
-        list($firstName, $lastName) = $this->getAmazonName($amazonProfile['name']);
+        list($firstName, $lastName) = Amazon_Payments_Helper_Data::getAmazonName($amazonProfile['name']);
 
         try {
             $this


### PR DESCRIPTION
This attempts to fix an issue with #328 

The fix unifies the usage of `getAmazonName` method and extracts the method from Model into Helper, so that it's usable by `transformAmazonAddressToMagentoAddress` method.

By doing so, the extraction logic of first/last name is now consistent.
The key point is - last name is considered as . (dot) in case the extraction can't split the name into two. parts for Magento.