### PR TITLE
Fix duplicate "Discount Codes" text

### DIFF
--- a/app/design/frontend/base/default/template/amazon_payments/coupon.phtml
+++ b/app/design/frontend/base/default/template/amazon_payments/coupon.phtml
@@ -9,8 +9,6 @@
  */
 ?>
 
-<h2><?php echo $this->__('Discount Codes') ?></h2>
-
 <form id="discount-coupon-form" action="<?php echo $this->getUrl('checkout/amazon_payments/couponPost') ?>" method="post">
     <div class="discount">
         <h2><?php echo $this->__('Discount Codes') ?></h2>


### PR DESCRIPTION
Issue seen when using Amazon Standalone Checkout as the Checkout Page Type