### PR TITLE
ASD-127 fix. Remove stacktrace from error messages

### DIFF
--- a/app/code/community/Amazon/Payments/Model/PaymentMethod.php
+++ b/app/code/community/Amazon/Payments/Model/PaymentMethod.php
@@ -370,20 +370,27 @@ class Amazon_Payments_Model_PaymentMethod extends Mage_Payment_Model_Method_Abst
             }
 
             if (!$this->_getErrorCheck() || $orderReferenceDetails->getOrderReferenceStatus()->getState() == 'Draft') {
-                $apiResult = $this->_getApi()->setOrderReferenceDetails(
-                    $orderReferenceId,
-                    $order->getBaseGrandTotal(),
-                    $order->getBaseCurrencyCode(),
-                    $order->getIncrementId(),
-                    $this->_getApi()->getConfig()->getStoreName()
-                );
+                try {
+                    $apiResult = $this->_getApi()->setOrderReferenceDetails(
+                        $orderReferenceId,
+                        $order->getBaseGrandTotal(),
+                        $order->getBaseCurrencyCode(),
+                        $order->getIncrementId(),
+                        $this->_getApi()->getConfig()->getStoreName()
+                    );
+                }
+                catch (Exception $e) {
+                    Mage::throwException("There was an error processing your payment. Please reload the page and try again.");
+                    $this->_setErrorCheck();
+                    return;
+                }
             }
 
             try {
                 $apiResult = $this->_getApi()->confirmOrderReference($orderReferenceId);
             }
             catch (Exception $e) {
-                Mage::throwException("Please try another Amazon payment method." . "\n\n" . substr($e->getMessage(), 0, strpos($e->getMessage(), 'Stack trace')));
+                Mage::throwException("Please try another Amazon payment method.");
                 $this->_setErrorCheck();
                 return;
             }


### PR DESCRIPTION
This is related to the ticket I opened for ASD-127.
In certain cases, the buyer would be shown an error message that included a stacktrace. The stacktrace is not useful for the buyer, and the stacktrace is logged anyway to the exception log (if logging is enabled).

I noticed another place an error could happen that wasn't being caught properly and bubbling up to the client API code.

Here is the error example which I am removing the stacktrace from the log message:


```
Payment transaction failed.
--
ReasonPlease try another Amazon payment method. exception 'OffAmazonPaymentsService_Exception' with message 'The OrderReferenceId P01-9772424-4423818 has constraints PaymentPlanNotSet and cannot be confirmed.' in /chroot/home/marvgold/marvgolden.com/html/lib/OffAmazonPaymentsService/Client.php:920

```


Here is the error that I am adding the additional try/catch block to:

> 
> Payment transaction failed.
> --
> Reasonexception 'OffAmazonPaymentsService_Exception' with message 'OrderReference P01-1704363-8564520 is not in draft state and cannot be modified with the request submitted by you.' in /chroot/home/marvgold/marvgolden.com/html/lib/OffAmazonPaymentsService/Client.php:920 Stack trace: #0 /chroot/home/marvgold/marvgolden.com/html/lib/OffAmazonPaymentsService/Client.php(868): OffAmazonPaymentsService_Client->_reportAnyErrors('_invoke(Array) #2 /chroot/home/marvgold/marvgolden.com/html/app/code/community/Amazon/Payments/Model/Api.php(98): OffAmazonPaymentsService_Client->setOrderReferenceDetails(Object(OffAmazonPaymentsService_Model_SetOrderReferenceDetailsRequest)) #3 /chroot/home/marvgold/marvgolden.com/html/app/code/community/Amazon/Payments/Model/Api.php(306): Amazon_Payments_Model_Api->request('setOrderReferen...', Array) #4 /chroot/home/marvgold/marvgolden.com/html/app/code/community/Amazon/Payments/Model/PaymentMethod.php(379): Amazon_Payments_Model_Api->setOrderReferenceDetails('P01-1704363-856...', 418.61, 'USD', '1352422', 'Marv Golden Pil...') #5 /chroot/home/marvgold/marvgolden.com/html/app/code/community/Amazon/Payments/Model/PaymentMethod.php(121): Amazon_Payments_Model_PaymentMethod->order(Object(Mage_Sales_Model_Order_Payment), 418.61) #6 /chroot/home/marvgold/marvgolden.com/html/app/code/local/Mage/Sales/Model/Order/Payment.php(334): Amazon_Payments_Model_PaymentMethod->initialize('authorize', Object(Varien_Object)) #7 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Sales/Model/Order.php(896): Mage_Sales_Model_Order_Payment->place() #8 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Sales/Model/Order.php(1114): Mage_Sales_Model_Order->_placePayment() #9 [internal function]: Mage_Sales_Model_Order->place() #10 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Model/Resource/Transaction.php(105): call_user_func(Array) #11 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Model/Resource/Transaction.php(159): Mage_Core_Model_Resource_Transaction->_runCallbacks() #12 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Sales/Model/Service/Quote.php(189): Mage_Core_Model_Resource_Transaction->save() #13 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Sales/Model/Service/Quote.php(249): Mage_Sales_Model_Service_Quote->submitOrder() #14 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Checkout/Model/Type/Onepage.php(819): Mage_Sales_Model_Service_Quote->submitAll() #15 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Checkout/controllers/OnepageController.php(599): Mage_Checkout_Model_Type_Onepage->saveOrder() #16 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Controller/Varien/Action.php(418): Mage_Checkout_OnepageController->saveOrderAction() #17 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Controller/Varien/Router/Standard.php(254): Mage_Core_Controller_Varien_Action->dispatch('saveOrder') #18 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Controller/Varien/Front.php(172): Mage_Core_Controller_Varien_Router_Standard->match(Object(Mage_Core_Controller_Request_Http)) #19 /chroot/home/marvgold/marvgolden.com/html/app/code/core/Mage/Core/Model/App.php(365): Mage_Core_Controller_Varien_Front->dispatch() #20 /chroot/home/marvgold/marvgolden.com/html/app/Mage.php(684): Mage_Core_Model_App->run(Array) #21 /chroot/home/marvgold/marvgolden.com/html/index.php(85): Mage::run('', 'store') #22 {main}
> 
