### PR TITLE
Alexa Delivery Notifications

### DIFF
--- a/app/code/community/Amazon/Payments/Model/Alexa.php
+++ b/app/code/community/Amazon/Payments/Model/Alexa.php
@@ -91,7 +91,7 @@ class Amazon_Payments_Model_Alexa
                         $response->reasonCode . ': ' . $response->message;
 
                     if (strpos($response->message, 'missing key') !== false) {
-                        $errorMessage = 'Please add the missing Private key value in the Alexa delivery notification settings in Amazon Pay.';
+                        $errorMessage = 'Please add the missing Private/Public key value in the Alexa Delivery Notification settings in Amazon Pay to enable Delivery Notifications.';
                     }
 
                     Mage::getSingleton('adminhtml/session')->addNotice($errorMessage);

--- a/app/code/community/Amazon/Payments/Model/Alexa.php
+++ b/app/code/community/Amazon/Payments/Model/Alexa.php
@@ -40,7 +40,7 @@ class Amazon_Payments_Model_Alexa
             'public_key_id' => $this->getConfig()->getAlexaPublicKeyId(),
             'private_key'   => $this->getConfig()->getAlexaPrivateKey(),
             'sandbox'       => false, // deliveryTrackers not available in sandbox mode
-            'region'        => $this->getRegion()
+            'region'        => $this->getConfig()->getRegion()
         );
 
         $client = new AmazonPayV2_Client($amazonpay_config);
@@ -127,22 +127,6 @@ class Amazon_Payments_Model_Alexa
     private function getConfig()
     {
         return Mage::getSingleton('amazon_payments/config');
-    }
-
-    /**
-     * Return region
-     */
-    private function getRegion()
-    {
-        $region = $this->getConfig()->getRegion();
-        switch ($region) {
-            case 'uk':
-            case 'de':
-                return 'eu';
-                break;
-            default:
-                return $region;
-        }
     }
 
     /**

--- a/app/code/community/Amazon/Payments/Model/Alexa.php
+++ b/app/code/community/Amazon/Payments/Model/Alexa.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Amazon Payments
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Model_Alexa
+{
+    protected $logFile = 'amazon_delivery_notifications.log';
+    private $carriers;
+
+    public function __construct()
+    {
+        // Map carrier title to carrier code
+        $path = Mage::getBaseDir('lib') . DS . 'AmazonPayV2' . DS . 'amazon-pay-delivery-tracker-supported-carriers.csv';
+        $csv = new Varien_File_Csv();
+        $this->carriers = array_change_key_case($csv->getDataPairs($path), CASE_LOWER);
+    }
+
+    /**
+     * Submit Alexa delivery notification
+     *
+     * @param $orderReference string Amazon's OrderReferenceId
+     * @param $track Mage_Sales_Model_Order_Shipment_Track
+     */
+    //public function addDeliveryNotification($carrierCode, $trackingNumber)
+    public function addDeliveryNotification($orderReference, $track)
+    {
+        /** @var Mage_Sales_Model_Order_Shipment */
+        $shipment = $track->getShipment();
+
+        // Shipment created through API, not admin
+        $isMageApi = Mage::getSingleton('api/server')->getAdapter();
+
+        $amazonpay_config = array(
+            'public_key_id' => $this->getConfig()->getAlexaPublicKeyId(),
+            'private_key'   => $this->getConfig()->getAlexaPrivateKey(),
+            'sandbox'       => false, // deliveryTrackers not available in sandbox mode
+            'region'        => $this->getRegion()
+        );
+
+        $client = new AmazonPayV2_Client($amazonpay_config);
+
+        $trackerNumber = $track->getTrackNumber();
+        $carrierCode   = $this->mapCarrierCode($track->getCarrierCode(), $track->getTitle());
+
+        $payload = array(
+            'amazonOrderReferenceId' => $orderReference,
+            'deliveryDetails' => array(array(
+                'trackingNumber' => $trackerNumber,
+                'carrierCode' => $carrierCode,
+            ))
+        );
+
+        $payload = json_encode($payload);
+        $result = array();
+
+        try {
+            $result = $client->deliveryTrackers($payload);
+        }
+        catch (Exception $exception) {
+            Mage::logException($exception);
+            Mage::throwException($exception);
+        }
+
+        // Is transaction/debug logging enabled?
+        if (Mage::getStoreConfig('payment/amazon_payments/debug')) {
+            Mage::log(print_r($result, true) . "\n", null, $this->logFile);
+        }
+
+        if (!empty($result['status'])) {
+            if ($result['status'] == '200') {
+                $comment = Mage::helper('core')->__('Alexa Delivery Tracker saved for carrier %s tracking number %s.',
+                    $carrierCode, $trackerNumber);
+
+                $shipment->addComment($comment);
+                $shipment->setData('is_resave', true);
+                $shipment->save();
+
+                if (!$isMageApi) {
+                    Mage::getSingleton('adminhtml/session')->addSuccess($comment);
+                }
+            } else {
+                if (!$isMageApi) {
+                    $response = json_decode($result['response']);
+                    $errorMessage = 'Alexa Delivery Tracker returned a ' . $result['status'] . ' error: ' . "\n" .
+                        $response->reasonCode . ': ' . $response->message;
+                    Mage::getSingleton('adminhtml/session')->addError($errorMessage);
+                }
+            }
+        }
+
+        return $result;
+    }
+
+
+    /**
+     * Generate and save new public/private keys
+     */
+    public function generateKeys()
+    {
+        $rsa = new Zend_Crypt_Rsa;
+        $keys = $rsa->generateKeys(array('private_key_bits' => 2048, 'privateKeyBits' => 2048, 'hashAlgorithm' => 'sha1'));
+
+        Mage::getConfig()
+            ->saveConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY,
+                $keys['publicKey'],'default', 0)
+            ->saveConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PRIVKEY,
+                Mage::helper('core')->encrypt($keys['privateKey']), 'default', 0);
+        Mage::app()->cleanCache();
+    }
+
+    /**
+     * Get Amazon Payments config
+     *
+     * @return Amazon_Payments_Model_Config
+     */
+    private function getConfig()
+    {
+        return Mage::getSingleton('amazon_payments/config');
+    }
+
+    /**
+     * Return region
+     */
+    private function getRegion()
+    {
+        $region = $this->getConfig()->getRegion();
+        switch ($region) {
+            case 'uk':
+            case 'de':
+                return 'eu';
+                break;
+            default:
+                return $region;
+        }
+    }
+
+    /**
+     * Return carrier code
+     */
+    private function mapCarrierCode($code, $title = '')
+    {
+        if (isset($this->carriers[strtolower($title)])) {
+            return $this->carriers[strtolower($title)];
+        }
+
+        if (stripos($code, 'usps') !== false) {
+            return 'USPS';
+        }
+
+        if (stripos($code, 'ups') !== false) {
+            return 'UPS';
+        }
+
+        if (stripos($code, 'fedex') !== false) {
+            return 'FEDEX';
+        }
+        return strtoupper($code);
+    }
+
+
+}

--- a/app/code/community/Amazon/Payments/Model/Alexa.php
+++ b/app/code/community/Amazon/Payments/Model/Alexa.php
@@ -74,7 +74,7 @@ class Amazon_Payments_Model_Alexa
 
         if (!empty($result['status'])) {
             if ($result['status'] == '200') {
-                $comment = Mage::helper('core')->__('Alexa Delivery Tracker saved for carrier %s tracking number %s.',
+                $comment = Mage::helper('core')->__('Amazon Pay has received shipping tracking information for carrier %s and tracking number %s.',
                     $carrierCode, $trackerNumber);
 
                 $shipment->addComment($comment);
@@ -89,7 +89,12 @@ class Amazon_Payments_Model_Alexa
                     $response = json_decode($result['response']);
                     $errorMessage = 'Alexa Delivery Tracker returned a ' . $result['status'] . ' error: ' . "\n" .
                         $response->reasonCode . ': ' . $response->message;
-                    Mage::getSingleton('adminhtml/session')->addError($errorMessage);
+
+                    if (strpos($response->message, 'missing key') !== false) {
+                        $errorMessage = 'Please add the missing Private key value in the Alexa delivery notification settings in Amazon Pay.';
+                    }
+
+                    Mage::getSingleton('adminhtml/session')->addNotice($errorMessage);
                 }
             }
         }

--- a/app/code/community/Amazon/Payments/Model/Config.php
+++ b/app/code/community/Amazon/Payments/Model/Config.php
@@ -45,6 +45,11 @@ class Amazon_Payments_Model_Config
     const CONFIG_XML_PATH_LANGUAGE       = 'amazon_login/settings/language';
     const CONFIG_XML_PATH_LOGIN_ENABLED  = 'amazon_login/settings/enabled';
 
+    const CONFIG_XML_PATH_ALEXA_ENABLED    = 'payment/amazon_payments/alexa_active';
+    const CONFIG_XML_PATH_ALEXA_PUBKEY_ID  = 'payment/amazon_payments/alexa_public_key_id';
+    const CONFIG_XML_PATH_ALEXA_PUBKEY     = 'payment/amazon_payments/alexa_public_key';
+    const CONFIG_XML_PATH_ALEXA_PRIVKEY    = 'payment/amazon_payments/alexa_private_key';
+
     /**
      * Retrieve config value for store by path
      *
@@ -397,6 +402,39 @@ class Amazon_Payments_Model_Config
     {
         $states = (string) $this->_getStoreConfig(self::CONFIG_XML_PATH_BLOCK_STATES, $store);
         return array_map('trim', explode(',', $states));
+    }
+
+    /**
+     * Is Alexa Delivery Notification enabled?
+     *
+     * @param   store $store
+     * @return  bool
+     */
+    public function isAlexaEnabled($store = null)
+    {
+        return ($this->_getStoreConfig(self::CONFIG_XML_PATH_ALEXA_ENABLED, $store));
+    }
+
+    /**
+     * Return Alexa Public Key ID
+     *
+     * @param   store $store
+     * @return  string
+     */
+    public function getAlexaPublicKeyId($store = null)
+    {
+        return $this->_getStoreConfig(self::CONFIG_XML_PATH_ALEXA_PUBKEY_ID, $store);
+    }
+
+    /**
+     * Return Alexa Private Key
+     *
+     * @param   store $store
+     * @return  string
+     */
+    public function getAlexaPrivateKey($store = null)
+    {
+        return trim(Mage::helper('core')->decrypt($this->_getStoreConfig(self::CONFIG_XML_PATH_ALEXA_PRIVKEY, $store)));
     }
 
 }

--- a/app/code/community/Amazon/Payments/Model/Observer/Shipment.php
+++ b/app/code/community/Amazon/Payments/Model/Observer/Shipment.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Amazon Payments
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Model_Observer_Shipment
+{
+    /**
+     * Event: controller_response_redirect
+     *
+     * Alexa Delivery Notification
+     */
+    public function alexaDeliveryNotification(Varien_Event_Observer $observer)
+    {
+        $config = Mage::getSingleton('amazon_payments/config');
+        if (!$config->isEnabled() || !$config->isAlexaEnabled()) {
+            return;
+        }
+
+        $event = $observer->getEvent();
+
+        /** @var Mage_Sales_Model_Order_Shipment */
+        $shipment = $event->getShipment();
+
+        if ($shipment->getOrder()->getPayment()->getMethod() != 'amazon_payments' || $shipment->getData('is_resave')) {
+            return;
+        }
+
+        /** @var Mage_Sales_Model_Resource_Order_Shipment_Track_Collection */
+        $tracks = $shipment->getTracksCollection();
+
+        /** @var Mage_Sales_Model_Order_Shipment_Track */
+        $track  = $tracks->getLastItem();
+
+        $orderReference = $shipment->getOrder()->getPayment()->getAdditionalInformation('order_reference');
+
+        // Has new tracking number?
+        if ($track->getData() && $track->getCreatedAt() == $track->getUpdatedAt()) {
+            $result = Mage::getSingleton('amazon_payments/alexa')
+                ->addDeliveryNotification($orderReference, $track);
+        }
+    }
+}

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Amazon payments
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core_Model_Config_Data
+{
+    /**
+     * Return dynamic help/comment text
+     */
+    public function getCommentText(Mage_Core_Model_Config_Element $element, $currentValue)
+    {
+        $helper = Mage::helper('adminhtml');
+        $generateUrl = $helper->getUrl('adminhtml/amazon_alexa/generate');
+        $downloadUrl = $helper->getUrl('adminhtml/amazon_alexa/download');
+
+        $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
+        $pubkey  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
+        $privkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PRIVKEY, $storeId);
+
+        if (!$privkey) {
+            return '<a href="' . $generateUrl . '">' . $helper->__('Generate a new public/private key pair for Amazon Pay') . '</a>';
+        }
+        else if ($pubkey) {
+            return '<a href="' . $downloadUrl . '">' . $helper->__('Download Public Key') . '</a>';
+        }
+    }
+}

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
@@ -20,14 +20,20 @@ class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core
         $downloadUrl = $helper->getUrl('adminhtml/amazon_alexa/download');
 
         $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
+        $pubkeyid  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY_ID, $storeId);
         $pubkey  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
         $privkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PRIVKEY, $storeId);
 
-        if (!$privkey) {
-            return '<a href="' . $generateUrl . '">' . $helper->__('Generate a new public/private key pair for Amazon Pay') . '</a>';
-        }
-        else if ($pubkey) {
-            return '<a href="' . $downloadUrl . '">' . $helper->__('Download Public Key') . '</a>';
+        if (!$pubkeyid) {
+            if (!$pubkey) {
+                Mage::getModel('amazon_payments/alexa')->generateKeys();
+                $pubkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
+            }
+            $merchantId = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_SELLER_ID, $storeId);
+            $subject = rawurlencode('Request for Amazon Pay Private Key for ' . $merchantId);
+            $body = rawurlencode("Merchant ID: $merchantId\n\nPublic Key:\n\n$pubkey");
+            return __('Please <a href="%s">contact</a> Amazon Pay to receive the Public Key ID.',
+                'mailto:Amazon-pay-delivery-notifications@amazon.com?subject=' . $subject . '&body=' . $body);
         }
     }
 }

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexacomment.php
@@ -30,7 +30,7 @@ class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core
                 $pubkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
             }
             $merchantId = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_SELLER_ID, $storeId);
-            $subject = rawurlencode('Request for Amazon Pay Private Key for ' . $merchantId);
+            $subject = rawurlencode('Request for Amazon Pay Public Key ID for ' . $merchantId);
             $body = rawurlencode("Merchant ID: $merchantId\n\nPublic Key:\n\n$pubkey");
             return __('Please <a href="%s">contact</a> Amazon Pay to receive the Public Key ID.',
                 'mailto:Amazon-pay-delivery-notifications@amazon.com?subject=' . $subject . '&body=' . $body);

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexaemailcomment.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexaemailcomment.php
@@ -8,7 +8,7 @@
  * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
  */
 
-class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core_Model_Config_Data
+class Amazon_Payments_Model_System_Config_Backend_Alexaemailcomment extends Mage_Core_Model_Config_Data
 {
     /**
      * Return dynamic help/comment text
@@ -16,8 +16,6 @@ class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core
     public function getCommentText(Mage_Core_Model_Config_Element $element, $currentValue)
     {
         $helper = Mage::helper('adminhtml');
-        $generateUrl = $helper->getUrl('adminhtml/amazon_alexa/generate');
-        $downloadUrl = $helper->getUrl('adminhtml/amazon_alexa/download');
 
         $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
         $pubkeyid  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY_ID, $storeId);
@@ -29,11 +27,13 @@ class Amazon_Payments_Model_System_Config_Backend_Alexacomment extends Mage_Core
                 Mage::getModel('amazon_payments/alexa')->generateKeys();
                 $pubkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
             }
-            $merchantId = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_SELLER_ID, $storeId);
-            $subject = rawurlencode('Request for Amazon Pay Public Key ID for ' . $merchantId);
-            $body = rawurlencode("Merchant ID: $merchantId\n\nPublic Key:\n\n$pubkey");
-            return __('Please <a href="%s">contact</a> Amazon Pay to receive the Public Key ID.',
-                'mailto:Amazon-pay-delivery-notifications@amazon.com?subject=' . $subject . '&body=' . $body);
+            if ($privkey) {
+                $merchantId = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_SELLER_ID, $storeId);
+                $subject = rawurlencode('Request for Amazon Pay Public Key ID for ' . $merchantId);
+                $body = rawurlencode("Merchant ID: $merchantId\n\nPublic Key:\n\n$pubkey");
+                return __('Please <a href="%s">contact</a> Amazon Pay to receive the Public Key ID.',
+                    'mailto:Amazon-pay-delivery-notifications@amazon.com?subject=' . $subject . '&body=' . $body);
+            }
         }
     }
 }

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexakeycomment.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexakeycomment.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Amazon payments
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Model_System_Config_Backend_Alexakeycomment extends Mage_Core_Model_Config_Data
+{
+    /**
+     * Return dynamic help/comment text
+     */
+    public function getCommentText(Mage_Core_Model_Config_Element $element, $currentValue)
+    {
+        $helper = Mage::helper('adminhtml');
+        $generateUrl = $helper->getUrl('adminhtml/amazon_alexa/generate');
+        $downloadUrl = $helper->getUrl('adminhtml/amazon_alexa/download');
+
+        $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
+        $pubkey  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
+        $privkey = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PRIVKEY, $storeId);
+
+        if (!$privkey) {
+            return '<a href="' . $generateUrl . '">' . $helper->__('Generate a new public/private key pair for Amazon Pay') . '</a>';
+        }
+        else if ($pubkey) {
+            return '<a href="' . $downloadUrl . '">' . $helper->__('Download Public Key') . '</a>';
+        }
+    }
+}

--- a/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexaprivatekey.php
+++ b/app/code/community/Amazon/Payments/Model/System/Config/Backend/Alexaprivatekey.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Amazon Payments
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Model_System_Config_Backend_Alexaprivatekey extends Mage_Core_Model_Config_Data
+{
+    private $_placeholder = '[encrypted]';
+
+    /**
+     * Encrypt private key
+     */
+    public function save()
+    {
+        $value = trim($this->getValue());
+
+        if ($value != $this->_placeholder) {
+            if ($value &&
+                strpos($value, 'BEGIN') === false &&
+                strpos($$value, 'END') === false
+            ) {
+                Mage::getSingleton('core/session')->addError(Mage::helper('adminhtml')->__('Please save your Amazon private key in PEM format (-----BEGIN RSA PRIVATE KEY-----)'));
+            } else {
+                $value = Mage::getModel('core/encryption')->encrypt($this->getValue());
+                $this->setValue($value);
+                return parent::save();
+            }
+        }
+    }
+
+    /**
+     * Set placeholder value
+     */
+    public function afterLoad()
+    {
+        if ($this->value) {
+            $this->value = $this->_placeholder;
+        }
+        $this->_afterLoad();
+    }
+}

--- a/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
+++ b/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
@@ -39,8 +39,8 @@ class Amazon_Payments_Adminhtml_Amazon_AlexaController extends Mage_Adminhtml_Co
 
         $downloadUrl = $this->getUrl('adminhtml/amazon_alexa/download');
         Mage::getSingleton('adminhtml/session')->addSuccess(
-            $this->__('Your Amazon Pay public/private keypair has been generated for Alexa Delivery Notification. ' .
-            '<a href="%s">Download Public Key</a>.', $downloadUrl)
+            $this->__('Your Amazon Pay public/private keypair has been generated for Alexa Delivery Notification.'
+            //'<a href="%s">Download Public Key</a>.', $downloadUrl)
         );
         $this->_redirect('adminhtml/system_config/edit/section/payment');
     }

--- a/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
+++ b/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Amazon Payments SimplePath
+ *
+ * @category    Amazon
+ * @package     Amazon_Payments
+ * @copyright   Copyright (c) 2014 Amazon.com
+ * @license     http://opensource.org/licenses/Apache-2.0  Apache License, Version 2.0
+ */
+
+class Amazon_Payments_Adminhtml_Amazon_AlexaController extends Mage_Adminhtml_Controller_Action
+{
+    /**
+     * Download public key
+     */
+    public function downloadAction()
+    {
+        $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
+        $pubkey  = Mage::getStoreConfig(Amazon_Payments_Model_Config::CONFIG_XML_PATH_ALEXA_PUBKEY, $storeId);
+        $file = 'amazon_public_key.pub';
+
+        header('Content-Description: File Transfer');
+        header('Content-Type: application/octet-stream');
+        header('Content-Disposition: attachment; filename="'.basename($file).'"');
+        header('Expires: 0');
+        header('Cache-Control: must-revalidate');
+        header('Pragma: public');
+        header('Content-Length: ' . strlen($pubkey));
+        $this->getResponse()->setBody($pubkey);
+    }
+
+    /**
+     * Generate public and private key
+     */
+    public function generateAction()
+    {
+        $storeId = Mage::getSingleton('adminhtml/config_data')->getStore();
+        Mage::getModel('amazon_payments/alexa')->generateKeys();
+
+        $downloadUrl = $this->getUrl('adminhtml/amazon_alexa/download');
+        Mage::getSingleton('adminhtml/session')->addSuccess(
+            $this->__('Your Amazon Pay public/private keypair has been generated for Alexa Delivery Notification. ' .
+            '<a href="%s">Download Public Key</a>.', $downloadUrl)
+        );
+        $this->_redirect('adminhtml/system_config/edit/section/payment');
+    }
+
+}

--- a/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
+++ b/app/code/community/Amazon/Payments/controllers/Adminhtml/Amazon/AlexaController.php
@@ -39,7 +39,7 @@ class Amazon_Payments_Adminhtml_Amazon_AlexaController extends Mage_Adminhtml_Co
 
         $downloadUrl = $this->getUrl('adminhtml/amazon_alexa/download');
         Mage::getSingleton('adminhtml/session')->addSuccess(
-            $this->__('Your Amazon Pay public/private keypair has been generated for Alexa Delivery Notification.'
+            $this->__('Your Amazon Pay public/private keypair has been generated for Alexa Delivery Notification.')
             //'<a href="%s">Download Public Key</a>.', $downloadUrl)
         );
         $this->_redirect('adminhtml/system_config/edit/section/payment');

--- a/app/code/community/Amazon/Payments/etc/config.xml
+++ b/app/code/community/Amazon/Payments/etc/config.xml
@@ -138,6 +138,14 @@
                     </amazon_payments_observer>
                 </observers>
             </sales_order_save_commit_after>
+            <sales_order_shipment_save_after>
+                <observers>
+                    <amazon_payments_observer>
+                        <class>Amazon_Payments_Model_Observer_Shipment</class>
+                        <method>alexaDeliveryNotification</method>
+                    </amazon_payments_observer>
+                </observers>
+            </sales_order_shipment_save_after>
         </events>
     </adminhtml>
     <frontend>

--- a/app/code/community/Amazon/Payments/etc/system.xml
+++ b/app/code/community/Amazon/Payments/etc/system.xml
@@ -587,7 +587,7 @@
                   </alexa_active>
                   <alexa_public_key_id translate="label">
                       <label>Public Key ID</label>
-                      <comment><model>amazon_payments/system_config_backend_alexacomment</model></comment>
+                      <comment><model>amazon_payments/system_config_backend_alexaemailcomment</model></comment>
                       <frontend_type>text</frontend_type>
                       <sort_order>20</sort_order>
                       <show_in_default>1</show_in_default>
@@ -599,6 +599,7 @@
                       <label>Private Key</label>
                       <frontend_type>textarea</frontend_type>
                       <backend_model>amazon_payments/system_config_backend_alexaprivatekey</backend_model>
+                      <comment><model>amazon_payments/system_config_backend_alexakeycomment</model></comment>
                       <sort_order>30</sort_order>
                       <show_in_default>1</show_in_default>
                       <show_in_website>1</show_in_website>

--- a/app/code/community/Amazon/Payments/etc/system.xml
+++ b/app/code/community/Amazon/Payments/etc/system.xml
@@ -567,6 +567,47 @@
                   </restricted_ips>
               </fields>
           </ap_developer>
+          <ap_alexa type="group" translate="label">
+              <label>Alexa Order Delivery Notifications</label>
+              <show_in_default>1</show_in_default>
+              <show_in_website>1</show_in_website>
+              <show_in_store>0</show_in_store>
+              <sort_order>50</sort_order>
+              <fields>
+                  <alexa_active translate="label">
+                      <label>Enable Alexa Order Delivery Notifications</label>
+                      <frontend_type>select</frontend_type>
+                      <source_model>adminhtml/system_config_source_yesno</source_model>
+                      <comment><![CDATA[<a href="" target="_blank">Refer here for more information on Alexa Order Delivery Notifications</a>]]></comment>
+                      <sort_order>10</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <config_path>payment/amazon_payments/alexa_active</config_path>
+                  </alexa_active>
+                  <alexa_public_key_id translate="label">
+                      <label>Public Key ID</label>
+                      <comment><![CDATA[Provided by Amazon Pay after submitting public key.]]></comment>
+                      <frontend_type>text</frontend_type>
+                      <sort_order>20</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <config_path>payment/amazon_payments/alexa_public_key_id</config_path>
+                  </alexa_public_key_id>
+                  <alexa_private_key translate="label">
+                      <label>Private Key</label>
+                      <frontend_type>textarea</frontend_type>
+                      <backend_model>amazon_payments/system_config_backend_alexaprivatekey</backend_model>
+                      <comment><model>amazon_payments/system_config_backend_alexacomment</model></comment>
+                      <sort_order>30</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <config_path>payment/amazon_payments/alexa_private_key</config_path>
+                  </alexa_private_key>
+              </fields>
+          </ap_alexa>
 
           </fields>
         </amazon_payments>

--- a/app/code/community/Amazon/Payments/etc/system.xml
+++ b/app/code/community/Amazon/Payments/etc/system.xml
@@ -568,44 +568,44 @@
               </fields>
           </ap_developer>
           <ap_alexa type="group" translate="label">
-              <label>Alexa Order Delivery Notifications</label>
+              <label>Alexa Delivery Notifications</label>
               <show_in_default>1</show_in_default>
               <show_in_website>1</show_in_website>
               <show_in_store>0</show_in_store>
               <sort_order>50</sort_order>
               <fields>
                   <alexa_active translate="label">
-                      <label>Enable Alexa Order Delivery Notifications</label>
+                      <label>Enable Alexa Delivery Notifications</label>
                       <frontend_type>select</frontend_type>
                       <source_model>adminhtml/system_config_source_yesno</source_model>
-                      <comment><![CDATA[<a href="" target="_blank">Refer here for more information on Alexa Order Delivery Notifications</a>]]></comment>
+                      <comment><![CDATA[<a href="https://github.com/amzn/amazon-payments-magento-plugin/wiki/Installation-and-Quick-Start-Guide#alexa-delivery-notifications" target="_blank">Refer here for more information on Alexa Delivery Notifications</a><style>#payment_ap_alexa_alexa_private_key{height:3.5em;}</style>]]></comment>
                       <sort_order>10</sort_order>
                       <show_in_default>1</show_in_default>
                       <show_in_website>1</show_in_website>
                       <show_in_store>0</show_in_store>
                       <config_path>payment/amazon_payments/alexa_active</config_path>
                   </alexa_active>
-                  <alexa_public_key_id translate="label">
-                      <label>Public Key ID</label>
-                      <comment><model>amazon_payments/system_config_backend_alexaemailcomment</model></comment>
-                      <frontend_type>text</frontend_type>
-                      <sort_order>20</sort_order>
-                      <show_in_default>1</show_in_default>
-                      <show_in_website>1</show_in_website>
-                      <show_in_store>0</show_in_store>
-                      <config_path>payment/amazon_payments/alexa_public_key_id</config_path>
-                  </alexa_public_key_id>
                   <alexa_private_key translate="label">
                       <label>Private Key</label>
                       <frontend_type>textarea</frontend_type>
                       <backend_model>amazon_payments/system_config_backend_alexaprivatekey</backend_model>
                       <comment><model>amazon_payments/system_config_backend_alexakeycomment</model></comment>
-                      <sort_order>30</sort_order>
+                      <sort_order>20</sort_order>
                       <show_in_default>1</show_in_default>
                       <show_in_website>1</show_in_website>
                       <show_in_store>0</show_in_store>
                       <config_path>payment/amazon_payments/alexa_private_key</config_path>
                   </alexa_private_key>
+                  <alexa_public_key_id translate="label">
+                      <label>Public Key ID</label>
+                      <comment><model>amazon_payments/system_config_backend_alexaemailcomment</model></comment>
+                      <frontend_type>text</frontend_type>
+                      <sort_order>30</sort_order>
+                      <show_in_default>1</show_in_default>
+                      <show_in_website>1</show_in_website>
+                      <show_in_store>0</show_in_store>
+                      <config_path>payment/amazon_payments/alexa_public_key_id</config_path>
+                  </alexa_public_key_id>
               </fields>
           </ap_alexa>
 

--- a/app/code/community/Amazon/Payments/etc/system.xml
+++ b/app/code/community/Amazon/Payments/etc/system.xml
@@ -587,7 +587,7 @@
                   </alexa_active>
                   <alexa_public_key_id translate="label">
                       <label>Public Key ID</label>
-                      <comment><![CDATA[Provided by Amazon Pay after submitting public key.]]></comment>
+                      <comment><model>amazon_payments/system_config_backend_alexacomment</model></comment>
                       <frontend_type>text</frontend_type>
                       <sort_order>20</sort_order>
                       <show_in_default>1</show_in_default>
@@ -599,7 +599,6 @@
                       <label>Private Key</label>
                       <frontend_type>textarea</frontend_type>
                       <backend_model>amazon_payments/system_config_backend_alexaprivatekey</backend_model>
-                      <comment><model>amazon_payments/system_config_backend_alexacomment</model></comment>
                       <sort_order>30</sort_order>
                       <show_in_default>1</show_in_default>
                       <show_in_website>1</show_in_website>

--- a/lib/AmazonPayV2/Client.php
+++ b/lib/AmazonPayV2/Client.php
@@ -373,7 +373,13 @@ class AmazonPayV2_Client implements AmazonPayV2_ClientInterface
     */
     public function createSignature($http_request_method, $request_uri, $request_parameters, $pre_signed_headers, $request_payload, $timeStamp)
     {
-        $rsa = new Crypt_RSA();
+        if (class_exists('Crypt_RSA', false)) {
+            $rsa = new Crypt_RSA();
+        } else {
+            // For newer versions of Magento
+            $rsa = new \phpseclib\Crypt\RSA();
+        }
+
         $rsa->setHash(self::HASH_ALGORITHM);
         $rsa->setMGFHash(self::HASH_ALGORITHM);
         $rsa->setSaltLength(20);

--- a/lib/AmazonPayV2/Client.php
+++ b/lib/AmazonPayV2/Client.php
@@ -1,494 +1,492 @@
 <?php
-/**
- * AmazonPayV2 SDK for Magento 1
- */
+    namespace AmazonPayV2;
 
-require_once 'ClientInterface.php';
-require_once 'HttpCurl.php';
+    use phpseclib\Crypt\RSA;
 
-class AmazonPayV2_Client implements AmazonPayV2_ClientInterface
-{
-    const SDK_VERSION = '4.1.0';
-    const HASH_ALGORITHM = 'sha256';
-    const AMAZON_SIGNATURE_ALGORITHM = 'AMZN-PAY-RSASSA-PSS';
-
-    private $config = array();
-
-    private $apiServiceUrls = array(
-        'eu' => 'pay-api-eu.amazon.com',
-        'na' => 'pay-api.amazon.com',
-        'jp' => 'pay-api-jp.amazon.com');
-
-    private $regionMappings = array(
-        'de' => 'eu',
-        'uk' => 'eu',
-        'us' => 'na',
-        'jp' => 'jp');
-
-    public function __construct($config = null) {
-
-        // include Magento's phpseclib
-        if (!class_exists('Crypt_RSA')) {
-            set_include_path(get_include_path() . PATH_SEPARATOR . Mage::getBaseDir('lib') . DIRECTORY_SEPARATOR  . 'phpseclib');
-            require_once('Crypt/RSA.php');
-        }
-
-        if (isset($config)) {
-
-            if (!is_array($config)) {
-                throw new \Exception('$config is of the incorrect type ' . gettype($config) . ' and should be of the type array');
-            }
-
-            $this->config = $config;
-
-            if (!empty($config['sandbox'])) {
-                // setSandbox verifies boolean
-                $this->setSandbox($config['sandbox']);
-            } else {
-                $this->setSandbox(false);
-            }
-
-        } else {
-            throw new \Exception('Expecting config array{region, sandbox, public_key_id, private_key}', 1);
-        }
-    }
-
-    /* Getter
-    *  Gets the value for the key if the key exists in config
-    */
-    public function __get($name)
+    require_once 'ClientInterface.php';
+    require_once 'HttpCurl.php';
+ 
+    class Client implements ClientInterface
     {
-        if (array_key_exists(strtolower($name), $this->config)) {
-            return $this->config[strtolower($name)];
-        } else {
-            throw new \Exception('Key ' . $name . ' is either not a part of the configuration array config or the ' . $name . ' does not match the key name in the config array', 1);
-        }
-    }
+        const SDK_VERSION = '4.1.3';
+        const HASH_ALGORITHM = 'sha256';
+        const AMAZON_SIGNATURE_ALGORITHM = 'AMZN-PAY-RSASSA-PSS';
 
-    /* Create API service URL and the Endpoint path */
-    private function createServiceUrl()
-    {
-        // Comprehensive SDK use requires 'sandbox' and 'region' parameters to be specified in the config array
-        // These attributes are not needed for Signature-only SDK usage
+        private $config = array();
 
-        $modePath = strtolower($this->config['sandbox']) ? 'sandbox' : 'live';
+        private $apiServiceUrls = array(
+            'eu' => 'pay-api.amazon.eu',
+            'na' => 'pay-api.amazon.com',
+            'jp' => 'pay-api.amazon.jp');
 
-        if (!empty($this->config['region'])) {
-            $region = strtolower($this->config['region']);
-            if (array_key_exists($region, $this->regionMappings)) {
+        private $regionMappings = array(
+            'eu' => 'eu',
+            'de' => 'eu',
+            'uk' => 'eu',
+            'us' => 'na',
+            'na' => 'na',
+            'jp' => 'jp');
 
-                if (isset($this->config['override_service_url'])) {
-                    $apiEndpointUrl  = preg_replace("(https?://)", "", $this->config['override_service_url']);
+        public function __construct($config = null) {
+            if (isset($config)) {
+
+                if (!is_array($config)) {
+                    throw new \Exception('$config is of the incorrect type ' . gettype($config) . ' and should be of the type array');
+                }
+
+                $this->config = $config;
+
+                if (!empty($config['sandbox'])) {
+                    // setSandbox verifies boolean
+                    $this->setSandbox($config['sandbox']);
                 } else {
-                    $apiEndpointUrl  = $this->apiServiceUrls[$this->regionMappings[$region]];
+                    $this->setSandbox(false);
                 }
 
-                return 'https://' . $apiEndpointUrl . '/' . $modePath . '/';
             } else {
-                throw new \Exception($region . ' is not a valid region');
+                throw new \Exception('Expecting config array{region, sandbox, public_key_id, private_key}', 1);
             }
-        } else {
-            throw new \Exception("config['region'] is a required parameter and is not set");
         }
-    }
 
-    /* canonicalURI
-    *  Strips the http and https off the URL
-    *  Strips the Host off the URL
-    *  Removes data after ?
-    *  Replaces special characters with their URL encoding
-    */
-    private function getCanonicalURI($unEncodedURI)
-    {
-        if ($unEncodedURI == '') {
-            return '/';
+        /* Getter
+        *  Gets the value for the key if the key exists in config
+        */
+        public function __get($name)
+        {
+            if (array_key_exists(strtolower($name), $this->config)) {
+                return $this->config[strtolower($name)];
+            } else {
+                throw new \Exception('Key ' . $name . ' is either not a part of the configuration array config or the ' . $name . ' does not match the key name in the config array', 1);
+            }
         }
-        $urlArray = parse_url($unEncodedURI);
-        if (empty($urlArray['path'])) {
-            return '/';
-        }
-        else {
-            return $urlArray['path'];
-        }
-    }
 
-    /* sortCanonicalArray
-    *  Sorts given array
-    *  Breaks out values in array that are arrays themselves and
-        returns a new array with that data
-    *  Creates new sorted array with all data
-    */
-    private function sortCanonicalArray($canonicalArray)
-    {
-        $sortedCanonicalArray = array();
-        foreach ($canonicalArray as $key => $val) {
-            if (is_array($val)) {
-                foreach ($this->subArrays($val, "$key") as $newKey => $subVal) {
-                    $sortedCanonicalArray["$newKey"] = $subVal;
+        /* Create API service URL and the Endpoint path */
+        private function createServiceUrl()
+        {
+            // Comprehensive SDK use requires 'sandbox' and 'region' parameters to be specified in the config array
+            // These attributes are not needed for Signature-only SDK usage
+
+            $modePath = strtolower($this->config['sandbox']) ? 'sandbox' : 'live';
+
+            if (!empty($this->config['region'])) {
+                $region = strtolower($this->config['region']);
+                if (array_key_exists($region, $this->regionMappings)) {
+
+                    if (isset($this->config['override_service_url'])) {
+                        $apiEndpointUrl  = preg_replace("(https?://)", "", $this->config['override_service_url']);
+                    } else {
+                        $apiEndpointUrl  = $this->apiServiceUrls[$this->regionMappings[$region]];
+                    }
+
+                    return 'https://' . $apiEndpointUrl . '/' . $modePath . '/';
+                } else {
+                    throw new \Exception($region . ' is not a valid region');
+                }
+            } else {
+                throw new \Exception("config['region'] is a required parameter and is not set");
+            }
+        }
+
+        /* canonicalURI
+        *  Strips the http and https off the URL
+        *  Strips the Host off the URL
+        *  Removes data after ?
+        *  Replaces special characters with their URL encoding
+        */
+        private function getCanonicalURI($unEncodedURI)
+        {
+            if ($unEncodedURI == '') {
+                return '/';
+            }
+            $urlArray = parse_url($unEncodedURI);
+            if (empty($urlArray['path'])) {
+                return '/';
+            }
+            else {
+                return $urlArray['path'];
+            }
+        }
+
+        /* sortCanonicalArray
+        *  Sorts given array 
+        *  Breaks out values in array that are arrays themselves and 
+            returns a new array with that data
+        *  Creates new sorted array with all data
+        */
+        private function sortCanonicalArray($canonicalArray)
+        {
+            $sortedCanonicalArray = array();
+            foreach ($canonicalArray as $key => $val) {
+                if (is_array($val)) {
+                    foreach ($this->subArrays($val, "$key") as $newKey => $subVal) {
+                        $sortedCanonicalArray["$newKey"] = $subVal;
+                    }
+                }
+                else if ((is_null($val)) || ($val == '')) {}
+                else {
+                    $sortedCanonicalArray["$key"] = $val;
                 }
             }
-            else if ((is_null($val)) || ($val == '')) {}
-            else {
-                $sortedCanonicalArray["$key"] = $val;
+            ksort($sortedCanonicalArray);
+
+            return $sortedCanonicalArray;
+        }
+
+        /* subArrays - helper function used to break out arays in an array */
+        private function subArrays($parameters, $catagory)
+        {
+            $categoryIndex = 0;
+            $newParameters = array();
+            $categoryString = "$catagory.";
+            foreach ($parameters as $value) {
+                $categoryIndex++;
+                $newParameters[$categoryString . $categoryIndex] = $value;
             }
-        }
-        ksort($sortedCanonicalArray);
 
-        return $sortedCanonicalArray;
-    }
-
-    /* subArrays - helper function used to break out arays in an array */
-    private function subArrays($parameters, $catagory)
-    {
-        $categoryIndex = 0;
-        $newParameters = array();
-        $categoryString = "$catagory.";
-        foreach ($parameters as $value) {
-            $categoryIndex++;
-            $newParameters[$categoryString . $categoryIndex] = $value;
+            return $newParameters;
         }
 
-        return $newParameters;
-    }
+        /* createCanonicalQuery
+        *  Returns a string of request parameters
+        */
+        private function createCanonicalQuery($requestParameters)
+        {
+            $sortedRequestParameters = $this->sortCanonicalArray($requestParameters);
 
-    /* createCanonicalQuery
-    *  Returns a string of request parameters
-    */
-    private function createCanonicalQuery($requestParameters)
-    {
-        $sortedRequestParameters = $this->sortCanonicalArray($requestParameters);
-
-        return $this->getParametersAsString($sortedRequestParameters);
-    }
-
-    /* Convert paremeters to Url encoded query string */
-    private function getParametersAsString(array $parameters)
-    {
-        $queryParameters = array();
-        foreach ($parameters as $key => $value) {
-            $queryParameters[] = $key . '=' . $this->urlEncode($value);
+            return $this->getParametersAsString($sortedRequestParameters);
         }
-        return implode('&', $queryParameters);
-    }
 
-    private function urlEncode($value)
-    {
-        return str_replace('%7E', '~', rawurlencode($value));
-    }
-
-    /* HexEncode and hash data */
-    private function hexAndHash($data)
-    {
-        $hash = self::HASH_ALGORITHM;
-        return bin2hex(hash($hash, $data, true));
-    }
-
-    /* Formats date as ISO 8601 timestamp */
-    private function getFormattedTimestamp()
-    {
-        return gmdate("Ymd\THis\\Z", time());
-    }
-
-    private function getCanonicalHeaders($headers)
-    {
-        $sortedCanonicalArray = array();
-        foreach ($headers as $key => $val) {
-            if ((is_null($val)) || ($val == '')) {}
-            else {
-                $sortedCanonicalArray[strtolower("$key")] = $val;
+        /* Convert paremeters to Url encoded query string */
+        private function getParametersAsString(array $parameters)
+        {
+            $queryParameters = array();
+            foreach ($parameters as $key => $value) {
+                $queryParameters[] = $key . '=' . $this->urlEncode($value);
             }
-        }
-        ksort($sortedCanonicalArray);
-
-        return $sortedCanonicalArray;
-    }
-
-    /* getCanonicalHeaderNames
-    *  Returns a string of the header names
-    */
-    private function getCanonicalHeadersNames($headers)
-    {
-        $sortedHeader = $this->getCanonicalHeaders($headers);
-        foreach (array_keys($sortedHeader) as $key) {
-            $parameters[] = $key;
-        }
-        ksort($parameters);
-        $headerNames = implode(';', $parameters);
-
-        return $headerNames;
-    }
-
-    /* getHost
-    *  Returns the host
-    */
-    private function getHost($unEncodedURI)
-    {
-        if ($unEncodedURI == '') {
-            return '/';
+            return implode('&', $queryParameters);
         }
 
-        $urlArray = parse_url($unEncodedURI);
-        if (empty($urlArray['host'])) {
-            return '/';
+        private function urlEncode($value)
+        {
+            return str_replace('%7E', '~', rawurlencode($value));
         }
-        else {
-            return $urlArray['host'];
+    
+        /* HexEncode and hash data */
+        private function hexAndHash($data)
+        {
+            $hash = self::HASH_ALGORITHM;
+            return bin2hex(hash($hash, $data, true));
         }
-    }
+    
+        /* Formats date as ISO 8601 timestamp */
+        private function getFormattedTimestamp()
+        {
+            return gmdate("Ymd\THis\\Z", time());
+        }
 
-    /* getHeaderString
-    *  Returns the Canonical Headers as a string
-    */
-    public function getHeaderString($headers)
-    {
-        $queryParameters = array();
-        $sortedHeaders = $this->getCanonicalHeaders($headers);
+        private function getCanonicalHeaders($headers)
+        {
+            $sortedCanonicalArray = array();
+            foreach ($headers as $key => $val) {
+                if ((is_null($val)) || ($val == '')) {}
+                else {
+                    $sortedCanonicalArray[strtolower("$key")] = $val;
+                }
+            }
+            ksort($sortedCanonicalArray);
 
-        foreach ($sortedHeaders as $key => $value) {
-            if (is_array($value)) {
-                $value = $this->collectSubVals($value);
+            return $sortedCanonicalArray;
+        }
+
+        /* getCanonicalHeaderNames
+        *  Returns a string of the header names
+        */
+        private function getCanonicalHeadersNames($headers)
+        {
+            $sortedHeader = $this->getCanonicalHeaders($headers);
+            foreach (array_keys($sortedHeader) as $key) {
+                $parameters[] = $key;
+            }
+            ksort($parameters);
+            $headerNames = implode(';', $parameters);
+
+            return $headerNames;
+        }
+
+        /* getHost
+        *  Returns the host
+        */
+        private function getHost($unEncodedURI)
+        {
+            if ($unEncodedURI == '') {
+                return '/';
+            }
+
+            $urlArray = parse_url($unEncodedURI);
+            if (empty($urlArray['host'])) {
+                return '/';
             }
             else {
+                return $urlArray['host'];
+            }
+        }
+
+        /* getHeaderString
+        *  Returns the Canonical Headers as a string
+        */
+        public function getHeaderString($headers)
+        {
+            $queryParameters = array();
+            $sortedHeaders = $this->getCanonicalHeaders($headers);
+            
+            foreach ($sortedHeaders as $key => $value) {
+                if (is_array($value)) {
+                    $value = $this->collectSubVals($value);
+                }
+                else {
+                    $queryParameters[] = $key . ':' . $value;
+                }
+            }
+            $returnString = implode("\n", $queryParameters);
+
+            return $returnString . "\n";
+        }
+
+        /* collectSubVals
+        *  Helper function to take an array and return the values as a string
+        */
+        private function collectSubVals($parameters)
+        {
+            $categoryIndex = 0;
+            $collectedValues = '';
+            
+            foreach ($parameters as $value) {
+                if ($categoryIndex != 0) {
+                    $collectedValues .= ' ';
+                }
+                $collectedValues .= $value;
+                $categoryIndex++;
+            }
+
+            return $collectedValues;
+        }
+
+        /* stringFromArray - helper function used to check if parameters is an array. 
+        *  If it is array it returns all the values as a string
+        *  Otherwise it returns parameters
+        */
+        private function stringFromArray($parameters)
+        {
+            if (is_array($parameters)) {
+                return $this->collectSubVals($parameters);
+            }
+            else {
+                return $parameters;
+            }
+        }
+
+        /* Create the User Agent Header sent with the POST request */
+        /* Protected because of PSP module usaged */
+        protected function constructUserAgentHeader()
+        {
+            return 'amazon-pay-sdk-php/' . self::SDK_VERSION . ' ('
+                . 'PHP/' . phpversion() . '; '
+                . php_uname('s') . '/' . php_uname('m') . '/' . php_uname('r') . ')';
+        }
+
+        /* checkForPaymentCriticalDataAPI - Takes the request uri and request payload, checks for
+        API names and modifies the payload if needed
+        @param $request_uri [String]
+        @param $http_request_method [String]
+        @param $request_payload [String]
+        */
+        private function checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload) {
+            $paymentCriticalDataAPIs = array('/live/account-management/v1/accounts', '/sandbox/account-management/v1/accounts');
+            $allowedHttpMethods = array('POST', 'PUT', 'PATCH');
+
+            // For APIs handling payment critical data, the payload shouldn't be
+            // considered in the signature calculation
+            foreach($paymentCriticalDataAPIs as $api) {
+                if (strpos($request_uri, $api) !== false && in_array($http_request_method, $allowedHttpMethods)) {
+                    return '';
+                }
+            }
+            return $request_payload;
+        }
+
+        /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and  
+        * returns an array of headers to be sent 
+        * @param $http_request_method [String] 
+        * @param $request_uri [String] 
+        * @param $request_parameters [Array()]
+        * @param $request_payload [String]
+        */
+        public function getPostSignedHeaders($http_request_method, $request_uri, $request_parameters, $request_payload)
+        {
+            $request_payload = $this->checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload);
+
+            $preSignedHeaders = array();
+            $preSignedHeaders['accept'] = 'application/json';
+            $preSignedHeaders['content-type'] = 'application/json';
+            $preSignedHeaders['X-Amz-Pay-Region'] = $this->config['region'];
+
+            $timeStamp = $this->getFormattedTimestamp();
+            $signature = $this->createSignature($http_request_method, $request_uri, $request_parameters, $preSignedHeaders, $request_payload, $timeStamp);
+            $public_key_id = $this->config['public_key_id'];
+
+            $headers = $this->getCanonicalHeaders($preSignedHeaders);
+            $headers['X-Amz-Pay-Date'] = $timeStamp;
+            $headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
+            $signedHeaders = "SignedHeaders=" . $this->getCanonicalHeadersNames($headers) . ", Signature=" . $signature;
+            
+            $headerArray = array(
+                'accept' => $this->stringFromArray($headers['accept']),
+                'content-type' => $this->stringFromArray($headers['content-type']),
+                'x-amz-pay-host' => $this->getHost($request_uri),
+                'x-amz-pay-date' => $timeStamp,
+                'x-amz-pay-region' => $this->config['region'],
+                'authorization' => self::AMAZON_SIGNATURE_ALGORITHM . " PublicKeyId=" . $public_key_id . ", " . $signedHeaders,
+                'user-agent' => $this->constructUserAgentHeader()
+            );
+
+            ksort($headerArray);
+            foreach ($headerArray as $key => $value) {
                 $queryParameters[] = $key . ':' . $value;
             }
+
+            return $queryParameters;
         }
-        $returnString = implode("\n", $queryParameters);
 
-        return $returnString . "\n";
-    }
+        /* createSignature convenience – Takes values for canonical request sorts and parses it and  
+        * returns a signature for the request being sent 
+        * @param $http_request_method [String] 
+        * @param $request_uri [String] 
+        * @param $request_parameters [Array()]
+        * @param $pre_signed_headers [Array()]
+        * @param $request_payload [String]
+        * @param $timeStamp [String]
+        */
+        public function createSignature($http_request_method, $request_uri, $request_parameters, $pre_signed_headers, $request_payload, $timeStamp)
+        {
+            $rsa = new RSA();
+            $rsa->setHash(self::HASH_ALGORITHM);
+            $rsa->setMGFHash(self::HASH_ALGORITHM);
+            $rsa->setSaltLength(20);
 
-    /* collectSubVals
-    *  Helper function to take an array and return the values as a string
-    */
-    private function collectSubVals($parameters)
-    {
-        $categoryIndex = 0;
-        $collectedValues = '';
+            $private_key = $this->config['private_key'];
+            
+            $pre_signed_headers['X-Amz-Pay-Date'] = $timeStamp;
+            $pre_signed_headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
 
-        foreach ($parameters as $value) {
-            if ($categoryIndex != 0) {
-                $collectedValues .= ' ';
+            $hashedPayload = $this->hexAndHash($request_payload);
+            $canonicalURI = $this->getCanonicalURI($request_uri);
+            $canonicalQueryString = $this->createCanonicalQuery($request_parameters);
+            $canonicalHeader = $this->getHeaderString($pre_signed_headers);
+            $signedHeaders = $this->getCanonicalHeadersNames($pre_signed_headers);
+            
+            $canonicalRequest = (
+                $http_request_method . "\n" .
+                $canonicalURI . "\n" .
+                $canonicalQueryString . "\n" .
+                $canonicalHeader . "\n" .
+                $signedHeaders . "\n" .
+                $hashedPayload
+            );
+
+            $hashedCanonicalRequest = self::AMAZON_SIGNATURE_ALGORITHM . "\n" . $this->hexAndHash($canonicalRequest);
+
+            if (strpos($private_key, 'BEGIN RSA PRIVATE KEY') === false) {
+                $rsa->loadKey(file_get_contents($private_key));
+            } else {
+                $rsa->loadKey($private_key);
             }
-            $collectedValues .= $value;
-            $categoryIndex++;
+            $signature = base64_encode($rsa->sign($hashedCanonicalRequest));
+            
+            return $signature;
         }
 
-        return $collectedValues;
-    }
 
-    /* stringFromArray - helper function used to check if parameters is an array.
-    *  If it is array it returns all the values as a string
-    *  Otherwise it returns parameters
-    */
-    private function stringFromArray($parameters)
-    {
-        if (is_array($parameters)) {
-            return $this->collectSubVals($parameters);
+        /* Signs and executes REST API call POST operation for arbitrary Amazon Pay v2 API
+         *
+         * @param urlFragment - [String] (e.g. 'v1/deliveryTrackers')
+         * @param payload - [String in JSON format] or [array]
+         * @optional authToken - [String]
+         */
+        public function apiPost($urlFragment, $payload, $authToken = null) {
+            if (is_array($payload)) {
+                $payload = json_encode($payload);
+            }
+
+            $url = $this->createServiceUrl() . $urlFragment;
+            $requestParameters = array();
+
+            $postSignedHeaders = $this->getPostSignedHeaders('POST', $url, $requestParameters, $payload);
+            if (isset($authToken)) {
+                $postSignedHeaders[] = 'x-amz-pay-authtoken:' . $authToken;
+            }
+
+            $httpCurlRequest = new HttpCurl();
+            $response = $httpCurlRequest->invokePost($url, $payload, $postSignedHeaders);
+            return $response;
         }
-        else {
-            return $parameters;
-        }
-    }
 
-    /* Create the User Agent Header sent with the POST request */
-    /* Protected because of PSP module usaged */
-    protected function constructUserAgentHeader()
-    {
-        return 'amazon-pay-sdk-php/' . self::SDK_VERSION . ' ('
-            . 'PHP/' . phpversion() . '; '
-            . php_uname('s') . '/' . php_uname('m') . '/' . php_uname('r') . ')';
-    }
-
-    /* checkForPaymentCriticalDataAPI - Takes the request uri and request payload, checks for
-    API names and modifies the payload if needed
-    @param $request_uri [String]
-    @param $http_request_method [String]
-    @param $request_payload [String]
-    */
-    private function checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload) {
-        $paymentCriticalDataAPIs = array('/live/account-management/v1/accounts', '/sandbox/account-management/v1/accounts');
-        $allowedHttpMethods = array('POST', 'PUT', 'PATCH');
-
-        // For APIs handling payment critical data, the payload shouldn't be
-        // considered in the signature calculation
-        foreach($paymentCriticalDataAPIs as $api) {
-            if (strpos($request_uri, $api) !== false && in_array($http_request_method, $allowedHttpMethods)) {
-                return '';
+        /* Setter for sandbox
+         * @param value - [boolean]
+         * Sets the boolean value for config['sandbox'] variable
+         */
+        public function setSandbox($value)
+        {
+            if (is_bool($value)) {
+                $this->config['sandbox'] = $value;
+            } else {
+                throw new \Exception('sandbox value ' . $value . ' is of type ' . gettype($value) . ' and should be a boolean value');
             }
         }
-        return $request_payload;
-    }
 
-    /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and
-    * returns an array of headers to be sent
-    * @param $http_request_method [String]
-    * @param $request_uri [String]
-    * @param $request_parameters [Array()]
-    * @param $request_payload [String]
-    */
-    public function getPostSignedHeaders($http_request_method, $request_uri, $request_parameters, $request_payload)
-    {
-        $request_payload = $this->checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload);
 
-        $preSignedHeaders = array();
-        $preSignedHeaders['accept'] = 'application/json';
-        $preSignedHeaders['content-type'] = 'application/json';
-        $preSignedHeaders['X-Amz-Pay-Region'] = $this->config['region'];
-
-        $timeStamp = $this->getFormattedTimestamp();
-        $signature = $this->createSignature($http_request_method, $request_uri, $request_parameters, $preSignedHeaders, $request_payload, $timeStamp);
-        $public_key_id = $this->config['public_key_id'];
-
-        $headers = $this->getCanonicalHeaders($preSignedHeaders);
-        $headers['X-Amz-Pay-Date'] = $timeStamp;
-        $headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
-        $signedHeaders = "SignedHeaders=" . $this->getCanonicalHeadersNames($headers) . ", Signature=" . $signature;
-
-        $headerArray = array(
-            'accept' => $this->stringFromArray($headers['accept']),
-            'content-type' => $this->stringFromArray($headers['content-type']),
-            'x-amz-pay-host' => $this->getHost($request_uri),
-            'x-amz-pay-date' => $timeStamp,
-            'x-amz-pay-region' => $this->config['region'],
-            'authorization' => self::AMAZON_SIGNATURE_ALGORITHM . " PublicKeyId=" . $public_key_id . ", " . $signedHeaders,
-            'user-agent' => $this->constructUserAgentHeader()
-        );
-
-        ksort($headerArray);
-        foreach ($headerArray as $key => $value) {
-            $queryParameters[] = $key . ':' . $value;
+        /* deliveryTrackers API call - Provides shipment tracking information for Alexa
+         *
+         * @param payload - [String in JSON format] or [array]
+         * @optional authToken - [String]
+         */
+        public function deliveryTrackers($payload, $authToken = null)
+        {
+            // Current implementation on deliveryTrackers API does not support the use of auth token
+            return $this->apiPost('v1/deliveryTrackers', $payload, $authToken);
         }
 
-        return $queryParameters;
-    }
 
-    /* createSignature convenience – Takes values for canonical request sorts and parses it and
-    * returns a signature for the request being sent
-    * @param $http_request_method [String]
-    * @param $request_uri [String]
-    * @param $request_parameters [Array()]
-    * @param $pre_signed_headers [Array()]
-    * @param $request_payload [String]
-    * @param $timeStamp [String]
-    */
-    public function createSignature($http_request_method, $request_uri, $request_parameters, $pre_signed_headers, $request_payload, $timeStamp)
-    {
-        if (class_exists('Crypt_RSA', false)) {
-            $rsa = new Crypt_RSA();
-        } else {
-            // For newer versions of Magento
-            $rsa = new \phpseclib\Crypt\RSA();
+        /* In-Store merchantScan API call - Generates Charge Permission ID from Amazon App's Amazon Pay QR Code
+         *
+         * @param payload - [String in JSON format] or [array]
+         * @optional authToken - [String]
+         */
+        public function instoreMerchantScan($payload, $authToken = null)
+        {
+            return $this->apiPost('in-store/v1/merchantScan', $payload, $authToken);
         }
 
-        $rsa->setHash(self::HASH_ALGORITHM);
-        $rsa->setMGFHash(self::HASH_ALGORITHM);
-        $rsa->setSaltLength(20);
-        $rsa->loadKey($this->config['private_key']);
 
-        $pre_signed_headers['X-Amz-Pay-Date'] = $timeStamp;
-        $pre_signed_headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
-
-        $hashedPayload = $this->hexAndHash($request_payload);
-        $canonicalURI = $this->getCanonicalURI($request_uri);
-        $canonicalQueryString = $this->createCanonicalQuery($request_parameters);
-        $canonicalHeader = $this->getHeaderString($pre_signed_headers);
-        $signedHeaders = $this->getCanonicalHeadersNames($pre_signed_headers);
-
-        $canonicalRequest = (
-            $http_request_method . "\n" .
-            $canonicalURI . "\n" .
-            $canonicalQueryString . "\n" .
-            $canonicalHeader . "\n" .
-            $signedHeaders . "\n" .
-            $hashedPayload
-        );
-
-        $hashedCanonicalRequest = self::AMAZON_SIGNATURE_ALGORITHM . "\n" . $this->hexAndHash($canonicalRequest);
-
-        $signature = base64_encode($rsa->sign($hashedCanonicalRequest));
-        return $signature;
-    }
-
-    /* Signs and executes REST API call POST operation for arbitrary Amazon Pay v2 API
-     *
-     * @param urlFragment - [String] (e.g. 'v1/deliveryTrackers')
-     * @param payload - [String in JSON format] or [array]
-     * @optional authToken - [String]
-     */
-    public function apiPost($urlFragment, $payload, $authToken = null) {
-        if (is_array($payload)) {
-            $payload = json_encode($payload);
+        /* In-Store charge API call - Performs Charge on a Charge Permission ID
+         *
+         * @param payload - [String in JSON format] or [array]
+         * @optional authToken - [String]
+         */
+        public function instoreCharge($payload, $authToken = null)
+        {
+            return $this->apiPost('in-store/v1/charge', $payload, $authToken);
         }
 
-        $url = $this->createServiceUrl() . $urlFragment;
-        $requestParameters = array();
 
-        if (isset($authToken)) {
-            $postSignedHeaders[] = 'x-amz-pay-authtoken:' . $authToken;
+        /* In-Store refund API call - Peforms Refund on a Charge ID                   
+         *
+         * @param payload - [String in JSON format] or [array]
+         * @optional authToken - [String]
+         */
+        public function instoreRefund($payload, $authToken = null)
+        {
+            return $this->apiPost('in-store/v1/refund', $payload, $authToken);
         }
 
-        $postSignedHeaders = $this->getPostSignedHeaders('POST', $url, $requestParameters, $payload);
-        $httpCurlRequest = new AmazonPayV2_HttpCurl();
-        $response = $httpCurlRequest->invokePost($url, $payload, $postSignedHeaders);
-        return $response;
     }
-
-    /* Setter for sandbox
-     * @param value - [boolean]
-     * Sets the boolean value for config['sandbox'] variable
-     */
-    public function setSandbox($value)
-    {
-        if (is_bool($value)) {
-            $this->config['sandbox'] = $value;
-        } else {
-            throw new \Exception('sandbox value ' . $value . ' is of type ' . gettype($value) . ' and should be a boolean value');
-        }
-    }
-
-
-    /* deliveryTrackers API call - Provides shipment tracking information for Alexa
-     *
-     * @param payload - [String in JSON format] or [array]
-     * @optional authToken - [String]
-     */
-    public function deliveryTrackers($payload, $authToken = null)
-    {
-        // Current implementation on deliveryTrackers API does not support the use of auth token
-        return $this->apiPost('v1/deliveryTrackers', $payload, $authToken);
-    }
-
-
-    /* In-Store merchantScan API call - Generates Charge Permission ID from Amazon App's Amazon Pay QR Code
-     *
-     * @param payload - [String in JSON format] or [array]
-     * @optional authToken - [String]
-     */
-    public function instoreMerchantScan($payload, $authToken = null)
-    {
-        return $this->apiPost('in-store/v1/merchantScan', $payload, $authToken);
-    }
-
-
-    /* In-Store charge API call - Performs Charge on a Charge Permission ID
-     *
-     * @param payload - [String in JSON format] or [array]
-     * @optional authToken - [String]
-     */
-    public function instoreCharge($payload, $authToken = null)
-    {
-        return $this->apiPost('in-store/v1/charge', $payload, $authToken);
-    }
-
-
-    /* In-Store refund API call - Peforms Refund on a Charge ID
-     *
-     * @param payload - [String in JSON format] or [array]
-     * @optional authToken - [String]
-     */
-    public function instoreRefund($payload, $authToken = null)
-    {
-        return $this->apiPost('in-store/v1/refund', $payload, $authToken);
-    }
-
-}
+?>

--- a/lib/AmazonPayV2/Client.php
+++ b/lib/AmazonPayV2/Client.php
@@ -1,0 +1,488 @@
+<?php
+/**
+ * AmazonPayV2 SDK for Magento 1
+ */
+
+require_once 'ClientInterface.php';
+require_once 'HttpCurl.php';
+
+class AmazonPayV2_Client implements AmazonPayV2_ClientInterface
+{
+    const SDK_VERSION = '4.1.0';
+    const HASH_ALGORITHM = 'sha256';
+    const AMAZON_SIGNATURE_ALGORITHM = 'AMZN-PAY-RSASSA-PSS';
+
+    private $config = array();
+
+    private $apiServiceUrls = array(
+        'eu' => 'pay-api-eu.amazon.com',
+        'na' => 'pay-api.amazon.com',
+        'jp' => 'pay-api-jp.amazon.com');
+
+    private $regionMappings = array(
+        'de' => 'eu',
+        'uk' => 'eu',
+        'us' => 'na',
+        'jp' => 'jp');
+
+    public function __construct($config = null) {
+
+        // include Magento's phpseclib
+        if (!class_exists('Crypt_RSA')) {
+            set_include_path(get_include_path() . PATH_SEPARATOR . Mage::getBaseDir('lib') . DIRECTORY_SEPARATOR  . 'phpseclib');
+            require_once('Crypt/RSA.php');
+        }
+
+        if (isset($config)) {
+
+            if (!is_array($config)) {
+                throw new \Exception('$config is of the incorrect type ' . gettype($config) . ' and should be of the type array');
+            }
+
+            $this->config = $config;
+
+            if (!empty($config['sandbox'])) {
+                // setSandbox verifies boolean
+                $this->setSandbox($config['sandbox']);
+            } else {
+                $this->setSandbox(false);
+            }
+
+        } else {
+            throw new \Exception('Expecting config array{region, sandbox, public_key_id, private_key}', 1);
+        }
+    }
+
+    /* Getter
+    *  Gets the value for the key if the key exists in config
+    */
+    public function __get($name)
+    {
+        if (array_key_exists(strtolower($name), $this->config)) {
+            return $this->config[strtolower($name)];
+        } else {
+            throw new \Exception('Key ' . $name . ' is either not a part of the configuration array config or the ' . $name . ' does not match the key name in the config array', 1);
+        }
+    }
+
+    /* Create API service URL and the Endpoint path */
+    private function createServiceUrl()
+    {
+        // Comprehensive SDK use requires 'sandbox' and 'region' parameters to be specified in the config array
+        // These attributes are not needed for Signature-only SDK usage
+
+        $modePath = strtolower($this->config['sandbox']) ? 'sandbox' : 'live';
+
+        if (!empty($this->config['region'])) {
+            $region = strtolower($this->config['region']);
+            if (array_key_exists($region, $this->regionMappings)) {
+
+                if (isset($this->config['override_service_url'])) {
+                    $apiEndpointUrl  = preg_replace("(https?://)", "", $this->config['override_service_url']);
+                } else {
+                    $apiEndpointUrl  = $this->apiServiceUrls[$this->regionMappings[$region]];
+                }
+
+                return 'https://' . $apiEndpointUrl . '/' . $modePath . '/';
+            } else {
+                throw new \Exception($region . ' is not a valid region');
+            }
+        } else {
+            throw new \Exception("config['region'] is a required parameter and is not set");
+        }
+    }
+
+    /* canonicalURI
+    *  Strips the http and https off the URL
+    *  Strips the Host off the URL
+    *  Removes data after ?
+    *  Replaces special characters with their URL encoding
+    */
+    private function getCanonicalURI($unEncodedURI)
+    {
+        if ($unEncodedURI == '') {
+            return '/';
+        }
+        $urlArray = parse_url($unEncodedURI);
+        if (empty($urlArray['path'])) {
+            return '/';
+        }
+        else {
+            return $urlArray['path'];
+        }
+    }
+
+    /* sortCanonicalArray
+    *  Sorts given array
+    *  Breaks out values in array that are arrays themselves and
+        returns a new array with that data
+    *  Creates new sorted array with all data
+    */
+    private function sortCanonicalArray($canonicalArray)
+    {
+        $sortedCanonicalArray = array();
+        foreach ($canonicalArray as $key => $val) {
+            if (is_array($val)) {
+                foreach ($this->subArrays($val, "$key") as $newKey => $subVal) {
+                    $sortedCanonicalArray["$newKey"] = $subVal;
+                }
+            }
+            else if ((is_null($val)) || ($val == '')) {}
+            else {
+                $sortedCanonicalArray["$key"] = $val;
+            }
+        }
+        ksort($sortedCanonicalArray);
+
+        return $sortedCanonicalArray;
+    }
+
+    /* subArrays - helper function used to break out arays in an array */
+    private function subArrays($parameters, $catagory)
+    {
+        $categoryIndex = 0;
+        $newParameters = array();
+        $categoryString = "$catagory.";
+        foreach ($parameters as $value) {
+            $categoryIndex++;
+            $newParameters[$categoryString . $categoryIndex] = $value;
+        }
+
+        return $newParameters;
+    }
+
+    /* createCanonicalQuery
+    *  Returns a string of request parameters
+    */
+    private function createCanonicalQuery($requestParameters)
+    {
+        $sortedRequestParameters = $this->sortCanonicalArray($requestParameters);
+
+        return $this->getParametersAsString($sortedRequestParameters);
+    }
+
+    /* Convert paremeters to Url encoded query string */
+    private function getParametersAsString(array $parameters)
+    {
+        $queryParameters = array();
+        foreach ($parameters as $key => $value) {
+            $queryParameters[] = $key . '=' . $this->urlEncode($value);
+        }
+        return implode('&', $queryParameters);
+    }
+
+    private function urlEncode($value)
+    {
+        return str_replace('%7E', '~', rawurlencode($value));
+    }
+
+    /* HexEncode and hash data */
+    private function hexAndHash($data)
+    {
+        $hash = self::HASH_ALGORITHM;
+        return bin2hex(hash($hash, $data, true));
+    }
+
+    /* Formats date as ISO 8601 timestamp */
+    private function getFormattedTimestamp()
+    {
+        return gmdate("Ymd\THis\\Z", time());
+    }
+
+    private function getCanonicalHeaders($headers)
+    {
+        $sortedCanonicalArray = array();
+        foreach ($headers as $key => $val) {
+            if ((is_null($val)) || ($val == '')) {}
+            else {
+                $sortedCanonicalArray[strtolower("$key")] = $val;
+            }
+        }
+        ksort($sortedCanonicalArray);
+
+        return $sortedCanonicalArray;
+    }
+
+    /* getCanonicalHeaderNames
+    *  Returns a string of the header names
+    */
+    private function getCanonicalHeadersNames($headers)
+    {
+        $sortedHeader = $this->getCanonicalHeaders($headers);
+        foreach (array_keys($sortedHeader) as $key) {
+            $parameters[] = $key;
+        }
+        ksort($parameters);
+        $headerNames = implode(';', $parameters);
+
+        return $headerNames;
+    }
+
+    /* getHost
+    *  Returns the host
+    */
+    private function getHost($unEncodedURI)
+    {
+        if ($unEncodedURI == '') {
+            return '/';
+        }
+
+        $urlArray = parse_url($unEncodedURI);
+        if (empty($urlArray['host'])) {
+            return '/';
+        }
+        else {
+            return $urlArray['host'];
+        }
+    }
+
+    /* getHeaderString
+    *  Returns the Canonical Headers as a string
+    */
+    public function getHeaderString($headers)
+    {
+        $queryParameters = array();
+        $sortedHeaders = $this->getCanonicalHeaders($headers);
+
+        foreach ($sortedHeaders as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->collectSubVals($value);
+            }
+            else {
+                $queryParameters[] = $key . ':' . $value;
+            }
+        }
+        $returnString = implode("\n", $queryParameters);
+
+        return $returnString . "\n";
+    }
+
+    /* collectSubVals
+    *  Helper function to take an array and return the values as a string
+    */
+    private function collectSubVals($parameters)
+    {
+        $categoryIndex = 0;
+        $collectedValues = '';
+
+        foreach ($parameters as $value) {
+            if ($categoryIndex != 0) {
+                $collectedValues .= ' ';
+            }
+            $collectedValues .= $value;
+            $categoryIndex++;
+        }
+
+        return $collectedValues;
+    }
+
+    /* stringFromArray - helper function used to check if parameters is an array.
+    *  If it is array it returns all the values as a string
+    *  Otherwise it returns parameters
+    */
+    private function stringFromArray($parameters)
+    {
+        if (is_array($parameters)) {
+            return $this->collectSubVals($parameters);
+        }
+        else {
+            return $parameters;
+        }
+    }
+
+    /* Create the User Agent Header sent with the POST request */
+    /* Protected because of PSP module usaged */
+    protected function constructUserAgentHeader()
+    {
+        return 'amazon-pay-sdk-php/' . self::SDK_VERSION . ' ('
+            . 'PHP/' . phpversion() . '; '
+            . php_uname('s') . '/' . php_uname('m') . '/' . php_uname('r') . ')';
+    }
+
+    /* checkForPaymentCriticalDataAPI - Takes the request uri and request payload, checks for
+    API names and modifies the payload if needed
+    @param $request_uri [String]
+    @param $http_request_method [String]
+    @param $request_payload [String]
+    */
+    private function checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload) {
+        $paymentCriticalDataAPIs = array('/live/account-management/v1/accounts', '/sandbox/account-management/v1/accounts');
+        $allowedHttpMethods = array('POST', 'PUT', 'PATCH');
+
+        // For APIs handling payment critical data, the payload shouldn't be
+        // considered in the signature calculation
+        foreach($paymentCriticalDataAPIs as $api) {
+            if (strpos($request_uri, $api) !== false && in_array($http_request_method, $allowedHttpMethods)) {
+                return '';
+            }
+        }
+        return $request_payload;
+    }
+
+    /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and
+    * returns an array of headers to be sent
+    * @param $http_request_method [String]
+    * @param $request_uri [String]
+    * @param $request_parameters [Array()]
+    * @param $request_payload [String]
+    */
+    public function getPostSignedHeaders($http_request_method, $request_uri, $request_parameters, $request_payload)
+    {
+        $request_payload = $this->checkForPaymentCriticalDataAPI($request_uri, $http_request_method, $request_payload);
+
+        $preSignedHeaders = array();
+        $preSignedHeaders['accept'] = 'application/json';
+        $preSignedHeaders['content-type'] = 'application/json';
+        $preSignedHeaders['X-Amz-Pay-Region'] = $this->config['region'];
+
+        $timeStamp = $this->getFormattedTimestamp();
+        $signature = $this->createSignature($http_request_method, $request_uri, $request_parameters, $preSignedHeaders, $request_payload, $timeStamp);
+        $public_key_id = $this->config['public_key_id'];
+
+        $headers = $this->getCanonicalHeaders($preSignedHeaders);
+        $headers['X-Amz-Pay-Date'] = $timeStamp;
+        $headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
+        $signedHeaders = "SignedHeaders=" . $this->getCanonicalHeadersNames($headers) . ", Signature=" . $signature;
+
+        $headerArray = array(
+            'accept' => $this->stringFromArray($headers['accept']),
+            'content-type' => $this->stringFromArray($headers['content-type']),
+            'x-amz-pay-host' => $this->getHost($request_uri),
+            'x-amz-pay-date' => $timeStamp,
+            'x-amz-pay-region' => $this->config['region'],
+            'authorization' => self::AMAZON_SIGNATURE_ALGORITHM . " PublicKeyId=" . $public_key_id . ", " . $signedHeaders,
+            'user-agent' => $this->constructUserAgentHeader()
+        );
+
+        ksort($headerArray);
+        foreach ($headerArray as $key => $value) {
+            $queryParameters[] = $key . ':' . $value;
+        }
+
+        return $queryParameters;
+    }
+
+    /* createSignature convenience – Takes values for canonical request sorts and parses it and
+    * returns a signature for the request being sent
+    * @param $http_request_method [String]
+    * @param $request_uri [String]
+    * @param $request_parameters [Array()]
+    * @param $pre_signed_headers [Array()]
+    * @param $request_payload [String]
+    * @param $timeStamp [String]
+    */
+    public function createSignature($http_request_method, $request_uri, $request_parameters, $pre_signed_headers, $request_payload, $timeStamp)
+    {
+        $rsa = new Crypt_RSA();
+        $rsa->setHash(self::HASH_ALGORITHM);
+        $rsa->setMGFHash(self::HASH_ALGORITHM);
+        $rsa->setSaltLength(20);
+        $rsa->loadKey($this->config['private_key']);
+
+        $pre_signed_headers['X-Amz-Pay-Date'] = $timeStamp;
+        $pre_signed_headers['X-Amz-Pay-Host'] = $this->getHost($request_uri);
+
+        $hashedPayload = $this->hexAndHash($request_payload);
+        $canonicalURI = $this->getCanonicalURI($request_uri);
+        $canonicalQueryString = $this->createCanonicalQuery($request_parameters);
+        $canonicalHeader = $this->getHeaderString($pre_signed_headers);
+        $signedHeaders = $this->getCanonicalHeadersNames($pre_signed_headers);
+
+        $canonicalRequest = (
+            $http_request_method . "\n" .
+            $canonicalURI . "\n" .
+            $canonicalQueryString . "\n" .
+            $canonicalHeader . "\n" .
+            $signedHeaders . "\n" .
+            $hashedPayload
+        );
+
+        $hashedCanonicalRequest = self::AMAZON_SIGNATURE_ALGORITHM . "\n" . $this->hexAndHash($canonicalRequest);
+
+        $signature = base64_encode($rsa->sign($hashedCanonicalRequest));
+        return $signature;
+    }
+
+    /* Signs and executes REST API call POST operation for arbitrary Amazon Pay v2 API
+     *
+     * @param urlFragment - [String] (e.g. 'v1/deliveryTrackers')
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function apiPost($urlFragment, $payload, $authToken = null) {
+        if (is_array($payload)) {
+            $payload = json_encode($payload);
+        }
+
+        $url = $this->createServiceUrl() . $urlFragment;
+        $requestParameters = array();
+
+        if (isset($authToken)) {
+            $postSignedHeaders[] = 'x-amz-pay-authtoken:' . $authToken;
+        }
+
+        $postSignedHeaders = $this->getPostSignedHeaders('POST', $url, $requestParameters, $payload);
+        $httpCurlRequest = new AmazonPayV2_HttpCurl();
+        $response = $httpCurlRequest->invokePost($url, $payload, $postSignedHeaders);
+        return $response;
+    }
+
+    /* Setter for sandbox
+     * @param value - [boolean]
+     * Sets the boolean value for config['sandbox'] variable
+     */
+    public function setSandbox($value)
+    {
+        if (is_bool($value)) {
+            $this->config['sandbox'] = $value;
+        } else {
+            throw new \Exception('sandbox value ' . $value . ' is of type ' . gettype($value) . ' and should be a boolean value');
+        }
+    }
+
+
+    /* deliveryTrackers API call - Provides shipment tracking information for Alexa
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function deliveryTrackers($payload, $authToken = null)
+    {
+        // Current implementation on deliveryTrackers API does not support the use of auth token
+        return $this->apiPost('v1/deliveryTrackers', $payload, $authToken);
+    }
+
+
+    /* In-Store merchantScan API call - Generates Charge Permission ID from Amazon App's Amazon Pay QR Code
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreMerchantScan($payload, $authToken = null)
+    {
+        return $this->apiPost('in-store/v1/merchantScan', $payload, $authToken);
+    }
+
+
+    /* In-Store charge API call - Performs Charge on a Charge Permission ID
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreCharge($payload, $authToken = null)
+    {
+        return $this->apiPost('in-store/v1/charge', $payload, $authToken);
+    }
+
+
+    /* In-Store refund API call - Peforms Refund on a Charge ID
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreRefund($payload, $authToken = null)
+    {
+        return $this->apiPost('in-store/v1/refund', $payload, $authToken);
+    }
+
+}

--- a/lib/AmazonPayV2/ClientInterface.php
+++ b/lib/AmazonPayV2/ClientInterface.php
@@ -1,0 +1,87 @@
+<?php
+//namespace AmazonPayV2;
+
+/* Interface class to showcase the public API methods for Amazon Pay */
+
+interface AmazonPayV2_ClientInterface
+{
+
+    // ----------- Comprehensive SDK API calls -----------
+
+    /* Setter for sandbox
+     * @param value - [boolean]
+     * Sets the boolean value for config['sandbox'] variable
+     */
+    public function setSandbox($value);
+
+
+    /* deliveryTrackers API call - Provides shipment tracking information for Alexa
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function deliveryTrackers($payload, $authToken = null);
+
+    /* In-Store merchantScan API call - Generates Charge Permission ID from Amazon App's Amazon Pay QR Code
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreMerchantScan($payload, $authToken = null);
+
+
+    /* In-Store charge API call - Performs Charge on a Charge Permission ID
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreCharge($payload, $authToken = null);
+
+
+    /* In-Store refund API call - Peforms Refund on a Charge ID
+     *
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function instoreRefund($payload, $authToken = null);
+
+
+    /* Getter for config attribute
+     * Gets the value for the key if the key exists in config
+     */
+    public function __get($name);
+
+    // ----------- Signature SDK API calls -----------
+
+    /* Signs and executes REST API call POST operation for arbitrary Amazon Pay v2 API
+     *
+     * @param urlFragment - [String] (e.g. 'v1/deliveryTrackers')
+     * @param payload - [String in JSON format] or [array]
+     * @optional authToken - [String]
+     */
+    public function apiPost($urlFragment, $payload, $authToken = null);
+
+
+    /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and
+     * returns an array of headers to be sent
+     * @param $http_request_method [String]
+     * @param $request_uri [String]
+     * @param $request_parameters [Array()]
+     * @param $request_payload [String]
+     */
+    public function getPostSignedHeaders($http_request_method, $request_uri, $request_parameters, $request_payload);
+
+
+    /* createSignature convenience – Takes values for canonical request sorts and parses it and
+     * returns a signature for the request being sent
+     * @param $http_request_method [String]
+     * @param $request_uri [String]
+     * @param $request_parameters [Array()]
+     * @param $pre_signed_headers [Array()]
+     * @param $request_payload [String]
+     * @param $timeStamp [String]
+     */
+    public function createSignature($http_request_method, $request_uri, $request_parameters, $pre_signed_headers, $request_payload, $timeStamp);
+
+}
+

--- a/lib/AmazonPayV2/ClientInterface.php
+++ b/lib/AmazonPayV2/ClientInterface.php
@@ -1,9 +1,9 @@
 <?php
-//namespace AmazonPayV2;
+namespace AmazonPayV2;
 
 /* Interface class to showcase the public API methods for Amazon Pay */
 
-interface AmazonPayV2_ClientInterface
+interface ClientInterface
 {
 
     // ----------- Comprehensive SDK API calls -----------
@@ -62,20 +62,20 @@ interface AmazonPayV2_ClientInterface
     public function apiPost($urlFragment, $payload, $authToken = null);
 
 
-    /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and
-     * returns an array of headers to be sent
-     * @param $http_request_method [String]
-     * @param $request_uri [String]
+    /* getPostSignedHeaders convenience – Takes values for canonical request, creates a signature and  
+     * returns an array of headers to be sent 
+     * @param $http_request_method [String] 
+     * @param $request_uri [String] 
      * @param $request_parameters [Array()]
      * @param $request_payload [String]
      */
     public function getPostSignedHeaders($http_request_method, $request_uri, $request_parameters, $request_payload);
 
 
-    /* createSignature convenience – Takes values for canonical request sorts and parses it and
-     * returns a signature for the request being sent
-     * @param $http_request_method [String]
-     * @param $request_uri [String]
+    /* createSignature convenience – Takes values for canonical request sorts and parses it and  
+     * returns a signature for the request being sent 
+     * @param $http_request_method [String] 
+     * @param $request_uri [String] 
      * @param $request_parameters [Array()]
      * @param $pre_signed_headers [Array()]
      * @param $request_payload [String]
@@ -85,3 +85,4 @@ interface AmazonPayV2_ClientInterface
 
 }
 
+?>

--- a/lib/AmazonPayV2/ClientInterface.php
+++ b/lib/AmazonPayV2/ClientInterface.php
@@ -1,9 +1,9 @@
 <?php
-namespace AmazonPayV2;
+//namespace AmazonPayV2;
 
 /* Interface class to showcase the public API methods for Amazon Pay */
 
-interface ClientInterface
+interface AmazonPayV2_ClientInterface
 {
 
     // ----------- Comprehensive SDK API calls -----------

--- a/lib/AmazonPayV2/HttpCurl.php
+++ b/lib/AmazonPayV2/HttpCurl.php
@@ -1,0 +1,138 @@
+<?php
+//namespace AmazonPayV2;
+
+/* Class HttpCurl
+ * Handles Curl POST function for all requests
+ */
+
+class AmazonPayV2_HttpCurl
+{
+    const MAX_ERROR_RETRY = 3;
+
+    private $header = false;
+    private $accessToken = null;
+    private $curlResponseInfo = null;
+    private $headerArray = array();
+
+    /* Takes user configuration array as input
+     * Takes configuration for API call or IPN config
+     */
+
+    private function commonCurlParams($url)
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_PORT, 443);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HEADER, false);
+        return $ch;
+    }
+
+
+    /* POST using curl for API V2 calls
+     */
+    private function httpPost($url, $payload, $postSignedHeaders)
+    {
+        // Ensure we never send the "Expect: 100-continue" header by adding
+        // an 'Expect:' header to the end of the headers
+        $postSignedHeaders[] = 'Expect:';
+
+        $ch = $this->commonCurlParams($url);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $postSignedHeaders);
+
+        $response = $this->execute($ch);
+        return $response;
+    }
+
+    /* Execute Curl request */
+    private function execute($ch)
+    {
+        $response = '';
+
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $error_msg = "Unable to post request, underlying exception of " . curl_error($ch);
+            curl_close($ch);
+            throw new \Exception($error_msg);
+        } else {
+            $this->curlResponseInfo = curl_getinfo($ch);
+        }
+        curl_close($ch);
+        return $response;
+    }
+
+    /* invokePost takes the parameters and invokes the httpPost function to POST the parameters
+     * Exponential retries on error 500 and 503
+     * The response from the POST is an XML which is converted to Array
+     */
+    public function invokePost($url, $payload, $postSignedHeaders)
+    {
+        $response = array();
+        $statusCode = 200;
+
+        // Submit the request and read response body
+        try {
+            $shouldRetry = true;
+            $retries = 0;
+            do {
+                try {
+                    $response = $this->httpPost($url, $payload, $postSignedHeaders);
+                    $curlResponseInfo = $this->curlResponseInfo;
+                    $statusCode = $curlResponseInfo["http_code"];
+                    $response = array(
+                        'status'   => $statusCode,
+                        'url'      => $url,
+                        'headers'  => $postSignedHeaders,
+                        'request'  => $payload,
+                        'response' => $response
+                    );
+
+                    $statusCode = $response['status'];
+                    if ($statusCode == 200) {
+                        $shouldRetry = false;
+                    } elseif ($statusCode == 500 || $statusCode == 503) {
+
+                        $shouldRetry = true;
+                        if ($shouldRetry) {
+                            $this->pauseOnRetry(++$retries, $response);
+                        }
+                    } else {
+                        $shouldRetry = false;
+                    }
+                } catch (\Exception $e) {
+                    throw $e;
+                }
+            } while ($shouldRetry);
+        } catch (\Exception $se) {
+            throw $se;
+        }
+
+        return $response;
+    }
+
+    /* Exponential sleep on failed request
+     * Up to three retries will occur if first reqest fails
+     * after 1.0 second, 2.2 seconds, and finally 7.0 seconds
+     * @param retries current retry
+     * @throws Exception if maximum number of retries has been reached
+     */
+    private function pauseOnRetry($retries, $response)
+    {
+        if ($retries <= self::MAX_ERROR_RETRY) {
+            // PHP delays are in microseconds (1 million microsecond = 1 sec)
+            // 1st delay is (4^1) * 100000 + 600000 = 0.4 + 0.6 second = 1.0 sec
+            // 2nd delay is (4^2) * 100000 + 600000 = 1.6 + 0.6 second = 2.2 sec
+            // 3rd delay is (4^3) * 100000 + 600000 = 6.4 + 0.6 second = 7.0 sec
+            $delay = (int) (pow(4, $retries) * 100000) + 600000;
+            usleep($delay);
+        } else {
+            throw new \Exception('Error Code: '. $response['status'] . ' - Maximum number of retry attempts - '
+                . $retries . " reached\n" . $response['response'] . "\n");
+        }
+    }
+
+}

--- a/lib/AmazonPayV2/HttpCurl.php
+++ b/lib/AmazonPayV2/HttpCurl.php
@@ -1,11 +1,11 @@
 <?php
-//namespace AmazonPayV2;
+namespace AmazonPayV2;
 
 /* Class HttpCurl
  * Handles Curl POST function for all requests
  */
 
-class AmazonPayV2_HttpCurl
+class HttpCurl
 {
     const MAX_ERROR_RETRY = 3;
 
@@ -20,7 +20,7 @@ class AmazonPayV2_HttpCurl
 
     private function commonCurlParams($url)
     {
-        $ch = curl_init();
+     	$ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_PORT, 443);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
@@ -131,7 +131,7 @@ class AmazonPayV2_HttpCurl
             usleep($delay);
         } else {
             throw new \Exception('Error Code: '. $response['status'] . ' - Maximum number of retry attempts - '
-                . $retries . " reached\n" . $response['response'] . "\n");
+              . $retries . " reached\n" . $response['response'] . "\n");
         }
     }
 

--- a/lib/AmazonPayV2/HttpCurl.php
+++ b/lib/AmazonPayV2/HttpCurl.php
@@ -1,11 +1,11 @@
 <?php
-namespace AmazonPayV2;
+//namespace AmazonPayV2;
 
 /* Class HttpCurl
  * Handles Curl POST function for all requests
  */
 
-class HttpCurl
+class AmazonPayV2_HttpCurl
 {
     const MAX_ERROR_RETRY = 3;
 

--- a/lib/AmazonPayV2/amazon-pay-delivery-tracker-supported-carriers.csv
+++ b/lib/AmazonPayV2/amazon-pay-delivery-tracker-supported-carriers.csv
@@ -1,0 +1,510 @@
+carrierName,carrierCode
+007EX,EX_007
+17 Post Service,POSTSERVICE_17
+2GO,GO_2
+360 Lion Express,LION_360
+4PX,PX_4
+Best Express,BESTEX_800
+AAA Cooper,AAA_COOPER
+AB Custom Group,ABCUSTOM
+ABF Freight,ABF
+ABX Express,ABXEXPRESS_MY
+aCommerce,ACOMMERCE
+ACS Courier,ACSCOURIER
+ACS Worldwide Express,ACSWORLDWIDE
+Adicional Logistics,ADICIONAL
+ADSOne,ADSONE
+A Duie Pyle,ADUIEPYLE
+Mexico AeroFlash,AEROFLASH
+Aersure,AERSURE
+AIR21,AIR21
+Airpak Express,AIRPAK_EXPRESS
+Airspeed International Corporation,AIRSPEED
+AlfaTrex,ALFATREX
+Allied Express,ALLIEDEXPRESS
+ALLJOY SUPPLY CHAIN CO.,ALLJOY
+alphaFAST,ALPHAFAST
+Amazon FBA USA,AMZN
+An Post,AN_POST
+APC Postal Logistics,APC
+APC Overnight,APC_OVERNIGHT
+APC Overnight Consignment Number,APC_OVERNIGHT_CONNUM
+Aprisa Express,APRISAEXPRESS
+Aramex,ARAMEX
+Arrow XL,ARROWXL
+Asendia Germany,ASENDIA_DE
+Asendia HK,ASENDIA_HK
+Asendia UK,ASENDIA_UK
+Asendia USA,ASENDIA_USA
+ASM,ASM
+AuPost China,AUPOST_CHINA
+Australia Post,AUSTRALIA_POST
+Austrian Post (Express),AUSTRIAN_POST
+Austrian Post (Registered),AUSTRIAN_POST_REGISTERED
+B2C Europe,B2CEUROPE
+Belpost,BELPOST
+Bert Transport,BERT_FR
+Best Way Parcel,BESTWAYPARCEL
+Bulgarian Posts,BGPOST
+JP BH Pošta,BH_POSTA
+B&H Worldwide,BH_WORLDWIDE
+BirdSystem,BIRDSYSTEM
+BJS Distribution,BJSHOMEDELIVERY
+Bluecare Express Ltd,BLUECARE
+Bluedart,BLUEDART
+Blue Star,BLUESTAR
+Bneed,BNEED
+Bonds Couriers,BONDSCOURIERS
+BoxC,BOXC
+Bpost,BPOST
+Bpost international,BPOST_INTERNATIONAL
+Brazil Correios,BRAZIL_CORREIOS
+BRT Bartolini,BRT_IT
+BRT Bartolini(Parcel ID),BRT_IT_PARCELID
+Buylogic,BUYLOGIC
+Cambodia Post,CAMBODIA_POST
+Canada Post,CANADA_POST
+Canpar Courier,CANPAR
+CBL Logistics,CBL_LOGISTICA
+Celeritas Transporte,CELERITAS
+Česká Pošta,CESKA_POSTA
+Champion Logistics,CHAMPION_LOGISTICS
+China EMS (ePacket),CHINA_EMS
+China Post,CHINA_POST
+Chit Chats,CHITCHATS
+C.H. Robinson Worldwide,CHROBINSON
+Chronopost France,CHRONOPOST_FRANCE
+Chronopost Portugal,CHRONOPOST_PORTUGAL
+City-Link Express,CITYLINKEXPRESS
+CJ GLS,CJ_GLS
+CJ Korea Express,CJ_KOREA_THAI
+CJ Century,CJ_MALAYSIA
+CJ Century (International),CJ_MALAYSIA_INTERNATIONAL
+CJ Transnational Philippines,CJ_PHILIPPINES
+CJ Logistics International,CJLOGISTICS
+Clevy Links,CLEVY_LINKS
+Cloudwish Asia,CLOUDWISH_ASIA
+CNE Express,CNEXPS
+Colis Privé,COLIS_PRIVE
+Colissimo,COLISSIMO
+CollectCo,COLLECTCO
+Collect+,COLLECTPLUS
+MDS Collivery Pty (Ltd),COLLIVERY
+Con-way Freight,CON_WAY
+Copa Airlines Courier,COPA_COURIER
+Correos Chile,CORREOS_CHILE
+Correos de Mexico,CORREOS_DE_MEXICO
+Correos Express,CORREOSEXPRESS
+Cosmetics Now,COSTMETICSNOW
+Urbanfox,COUREX
+Courier Plus,COURIER_PLUS
+Courier IT,COURIERIT
+CourierPost,COURIERPOST
+Couriers Please,COURIERS_PLEASE
+cPacket,CPACKET
+Cuckoo Express,CUCKOOEXPRESS
+Cyprus Post,CYPRUS_POST
+PostNord Denmark,DANMARK_POST
+Danske Fragtmænd,DANSKE_FRAGT
+Dawn Wing,DAWNWING
+DB Schenker,DBSCHENKER_SE
+DB Schenker Sweden,DBSCHENKER_SV
+DD Express Courier,DDEXPRESS
+Delcart,DELCART_IN
+Delhivery,DELHIVERY
+DELIVERYONTIME LOGISTICS PVT LTD,DELIVERYONTIME
+Deltec Courier,DELTEC_COURIER
+DemandShip,DEMANDSHIP
+Innovel,DESCARTES
+Detrack,DETRACK
+Deutsche Post Mail,DEUTSCH_POST
+DEX-I,DEX_I
+DHL Express,DHL
+DHL Active Tracing,DHL_ACTIVE_TRACING
+DHL Benelux,DHL_BENELUX
+DHL 2-Mann-Handling,DHL_DELIVERIT
+DHL Spain Domestic,DHL_ES
+Deutsche Post DHL,DHL_DE
+DHL Global Forwarding,DHL_GLOBAL_FORWARDING
+DHL eCommerce US,DHL_GLOBAL_MAIL
+DHL eCommerce Asia,DHL_GLOBAL_MAIL_ASIA
+DHL Hong Kong,DHL_HK
+DHL Netherlands,DHL_NL
+DHL Express (Piece ID),DHL_PIECEID
+DHL Poland Domestic,DHL_POLAND
+DHL Parcel Spain,DHLPARCEL_ES
+DHL Parcel NL,DHLPARCEL_NL
+Dimerco Express Group,DIMERCO
+Direct Freight Express,DIRECTFREIGHT_AU
+Direct Link,DIRECTLINK
+Directlog,DIRECTLOG
+DMM Network,DMM_NETWORK
+Doora Logistics,DOORA
+Dotzot,DOTZOT
+DPD,DPD
+DPD Germany,DPD_DE
+DPD HK,DPD_HK
+DPD Ireland,DPD_IRELAND
+DPD Poland,DPD_POLAND
+DPD Romania,DPD_RO
+DPD Russia,DPD_RU
+DPD UK,DPD_UK
+DPE Express,DPE_EXPRESS
+DPE South Africa,DPE_ZA
+DPEX,DPEX
+DSV,DSV
+DTDC India,DTDC
+DTDC Australia,DTDC_AU
+DTDC Express Global PTE LTD,DTDC_EXPRESS
+Daylight Transport,DYLT
+Dynamic Logistics,DYNAMIC_LOGISTICS
+Easy Mail,EASY_MAIL
+EC-Firstclass,EC_FIRSTCLASS
+Ecargo,ECARGO_ASIA
+Echo,ECHO
+ECMS International Logistics Co.,ECMS
+Ecom Express,ECOM_EXPRESS
+eFEx (E-Commerce Fulfillment & Express),EFEX
+EFS (E-commerce Fulfillment Service),EFS
+Ekart,EKART
+ELTA Hellenic Post,ELTA_COURIER
+Emirates Post,EMIRATES_POST
+EMPS Express,EMPSEXPRESS
+Endeavour Delivery,ENDEAVOUR_DELIVERY
+Ensenda,ENSENDA
+Envialia,ENVIALIA
+EP-Box,EP_BOX
+eParcel Korea,EPARCEL_KR
+Equick China,EQUICK_CN
+Estafeta,ESTAFETA
+Estes,ESTES
+eTotal Solution Limited,ETOTAL
+Eurodis,EURODIS
+DPD France,EXAPAQ
+Expeditors,EXPEDITORS
+Expeditors API,EXPEDITORS_API
+EZship,EZSHIP
+Fastrak Services,FASTRAK_TH
+Fastway Australia,FASTWAY_AU
+Fastway Ireland,FASTWAY_IRELAND
+Fastway New Zealand,FASTWAY_NZ
+Fastway South Africa,FASTWAY_ZA
+FedEx,FEDEX
+Fedex Cross Border,FEDEX_CROSSBORDER
+FedEx International MailService,FEDEX_FIMS
+FedEx Freight,FEDEX_FREIGHT
+FedEx UK,FEDEX_UK
+FERCAM Logistics & Transport,FERCAM
+First Flight Couriers,FIRST_FLIGHT
+First Logistics,FIRST_LOGISTICS
+Flyt Express,FLYTEXPRESS
+Gati-KWE,GATI_KWE
+GDEX,GDEX
+GEODIS - Distribution & Express,GEODIS_CALBERSON_FR
+Geodis E-space,GEODIS_ESPACE
+Giao hàng nhanh,GHN
+Globegistics Inc.,GLOBEGISTICS
+GLS,GLS
+GLS Czech Republic,GLS_CZ
+GLS Italy,GLS_ITALY
+GLS Netherlands,GLS_NETHERLANDS
+GoFly,GOFLY
+GoJavas,GOJAVAS
+Greyhound,GREYHOUND
+GSI EXPRESS,GSI_EXPRESS
+GSO,GSO
+Hermesworld,HERMES
+Hermes Germany,HERMES_DE
+Hermes Italy,HERMES_IT
+Hua Han Logistics,HH_EXP
+Holisol,HOLISOL
+Hong Kong Post,HONG_KONG_POST
+Hrvatska Pošta,HRVATSKA_POSTA
+Hunter Express,HUNTER_EXPRESS
+i-parcel,I_PARCEL
+IDEX,IDEXPRESS
+IMEX Global Solutions,IMEXGLOBALSOLUTIONS
+IMX Mail,IMXMAIL
+India Post Domestic,INDIA_POST
+India Post International,INDIA_POST_INT
+InPost Paczkomaty,INPOST_PACZKOMATY
+INSTANT (Tiong Nam Ebiz Express Sdn Bhd),INSTANT
+DPD Local,INTERLINK_EXPRESS
+DPD Local reference,INTERLINK_EXPRESS_REFERENCE
+International Seur,INTERNATIONAL_SEUR
+Internet Express,INTEXPRESS
+Israel Post,ISRAEL_POST
+Israel Post Domestic,ISRAEL_POST_DOMESTIC
+Italy SDA,ITALY_SDA
+J-Net,J_NET
+Jam Express,JAM_EXPRESS
+Janco Ecommerce,JANCO
+Japan Post,JAPAN_POST
+Jayon Express (JEX),JAYONEXPRESS
+JCEX,JCEX
+Jersey Post,JERSEY_POST
+Jet-Ship Worldwide,JET_SHIP
+JINSUNG TRADING,JINSUNG
+JNE,JNE
+Jocom,JOCOM
+J&T EXPRESS MALAYSIA,JTEXPRESS
+JX,JX
+K1 Express,K1_EXPRESS
+Kangaroo Worldwide Express,KANGAROO_MY
+Kerry Express Thailand,KERRY_LOGISTICS
+Kerry TJ Logistics,KERRYTJ
+Kerry Express (Vietnam) Co Ltd,KERRYTTC_VN
+KGM Hub,KGMHUB
+Kiala,KIALA
+Kuehne + Nagel,KN
+Korea Post EMS,KOREA_POST
+Korea Post,KPOST
+Shenzhen Jinghuada Logistics Co.,KWT
+La Poste,LA_POSTE_COLISSIMO
+Landmark Global,LANDMARK_GLOBAL
+Lao Post,LAO_POST
+LaserShip,LASERSHIP
+Latvijas Pasts,LATVIJAS_PASTS
+LBC Express,LBCEXPRESS
+LHT Express,LHT_EXPRESS
+Lietuvos Paštas,LIETUVOS_PASTAS
+Line Clear Express & Logistics Sdn Bhd,LINE
+Link Bridge(BeiJing)international logistics co.,LINKBRIDGE
+Lion Parcel,LION_PARCEL
+Lone Star Overnight,LONESTAR
+Logistic Worldwide Express,LWE_HK
+M Xpress Sdn Bhd,M_XPRESS
+Magyar Posta,MAGYAR_POSTA
+MailAmericas,MAILAMERICAS
+MailPlus,MAILPLUS
+Mainfreight,MAINFREIGHT
+Malaysia Post EMS / Pos Laju,MALAYSIA_POST
+Malaysia Post - Registered,MALAYSIA_POST_POSDAFTAR
+Mara Xpress,MARA_XPRESS
+Matdespatch,MATDESPATCH
+Matkahuolto,MATKAHUOLTO
+Megasave,MEGASAVE
+Mexico Redpack,MEXICO_REDPACK
+Mexico Senda Express,MEXICO_SENDA_EXPRESS
+PT MGLOBAL LOGISTICS INDONESIA,MGLOBAL
+Mikropakket,MIKROPAKKET
+Mondial Relay,MONDIALRELAY
+MRW,MRW_SPAIN
+MXE Express,MXE
+myHermes UK,MYHERMES_UK
+Mypostonline,MYPOSTONLINE
+NACEX Spain,NACEX_SPAIN
+Nanjing Woyuan,NANJINGWOYUAN
+National Sameday,NATIONAL_SAMEDAY
+Nationwide Express,NATIONWIDE_MY
+New Zealand Post,NEW_ZEALAND_POST
+Newgistics,NEWGISTICS
+Nhans Solutions,NHANS_SOLUTIONS
+Nightline,NIGHTLINE
+Nim Express,NIM_EXPRESS
+Ninja Van,NINJAVAN
+Ninja Van Indonesia,NINJAVAN_ID
+Ninja Van Malaysia,NINJAVAN_MY
+Ninja Van Philippines,NINJAVAN_PHILIPPINES
+Ninja Van Thailand,NINJAVAN_THAI
+NiPost,NIPOST
+Norsk Global,NORSK_GLOBAL
+Nova Poshta,NOVA_POSHTA
+Nova Poshta (International),NOVA_POSHTAINT
+OCA Argentina,OCA_AR
+OCS ANA Group,OCS
+Old Dominion Freight Line,OLD_DOMINION
+Omni Parcel,OMNIPARCEL
+Omniva,OMNIVA
+One World Express,ONEWORLDEXPRESS
+OnTrac,ONTRAC
+FedEx Poland Domestic,OPEK
+OSM Worldwide,OSM_WORLDWIDE
+Paack,PAACK_WEBHOOK
+Packlink,PACKLINK
+PAL Express Limited,PALEXPRESS
+Pandu Logistics,PANDULOGISTICS
+Panther,PANTHER
+Panther Order Number,PANTHER_ORDER_NUMBER
+Panther Reference,PANTHER_REFERENCE
+Paquetexpress,PAQUETEXPRESS
+Parcel Force,PARCEL_FORCE
+Parcel2Go,PARCEL2GO
+Parcelled.in,PARCELLED_IN
+ParcelPoint Pty Ltd,PARCELPOINT
+Parcel Post Singapore,PARCELPOST_SG
+PFC Express,PFCEXPRESS
+Pickupp,PICKUP
+PICK UPP,PICKUPP_MYS
+PICK UPP,PICKUPP_SGP
+Pilot Freight Services,PILOT_FREIGHT
+Pitney Bowes,PITNEY_BOWES
+PIXSELL LOGISTICS,PIXSELL
+Poczta Polska,POCZTA_POLSKA
+Portugal CTT,PORTUGAL_CTT
+Portugal Seur,PORTUGAL_SEUR
+Pos Indonesia Domestic,POS_INDONESIA
+Pos Indonesia Int'l,POS_INDONESIA_INT
+Post Serbia,POST_SERBIA
+Post of Slovenia,POST_SLOVENIA
+Post56,POST56
+Poșta Română,POSTA_ROMANA
+Poste Italiane,POSTE_ITALIANE
+Posten Norge / Bring,POSTEN_NORGE
+Posti,POSTI
+PostNL Domestic,POSTNL
+PostNL International 3S,POSTNL_3S
+PostNL International,POSTNL_INTERNATIONAL
+PostNord Logistics,POSTNORD
+Iceland Post,POSTUR_IS
+PayPal Package,PPBYB
+Professional Couriers,PROFESSIONAL_COURIERS
+PTT Posta,PTT_POSTA
+Purolator,PUROLATOR
+QualityPost,QUALITYPOST
+Quantium,QUANTIUM
+Qxpress,QXPRESS
+Raben Group,RABEN_GROUP
+RAF Philippines,RAF
+RaidereX,RAIDEREX
+RAM,RAMGROUP_ZA
+Red Carpet Logistics,RCL
+Redur Spain,REDUR_ES
+Rincos,RINCOS
+RL Carriers,RL_CARRIERS
+Roadbull Logistics,ROADBULL
+Rocket Parcel International,ROCKETPARCEL
+RPD2man Deliveries,RPD2MAN
+RPX Indonesia,RPX
+RPX Online,RPXONLINE
+RRD International Logistics U.S.A,RRDONNELLEY
+Russian Post,RUSSIAN_POST
+Ruston,RUSTON
+RZY Express,RZYEXPRESS
+Safexpress,SAFEXPRESS
+Sagawa,SAGAWA
+Saia LTL Freight,SAIA_FREIGHT
+SAILPOST,SAILPOST
+SAP EXPRESS,SAP_EXPRESS
+South African Post Office,SAPO
+Saudi Post,SAUDI_POST
+Scudex Express,SCUDEX_EXPRESS
+Southeastern Freight Lines,SEFL
+Seino,SEINO
+SEKO Logistics,SEKOLOGISTICS
+Sending Transporte Urgente y Comunicacion,SENDING
+Sendit,SENDIT
+Sendle,SENDLE
+S.F. Express,SF_EXPRESS
+SF Express (Webhook),SF_EXPRESS_WEBHOOK
+S.F International,SFB2C
+SFC Service,SFCSERVICE
+SGT Corriere Espresso,SGT_IT
+Shippit,SHIPPIT
+Shiptor,SHIPTOR
+ShopfansRU LLC,SHOPFANS
+Shree Maruti Courier Services Pvt Ltd,SHREE_MARUTI
+SHREE TIRUPATI COURIER SERVICES PVT. LTD.,SHREETIRUPATI
+Teliway SIC Express,SIC_TELIWAY
+SimplyPost,SIMPLYPOST
+Singapore Post,SINGAPORE_POST
+Singapore Speedpost,SINGAPORE_SPEEDPOST
+Siodemka,SIODEMKA
+SkyPostal,SKY_POSTAL
+SKYBOX,SKYBOX
+SkyNet Malaysia,SKYNET
+Skynet World Wide Express South Africa,SKYNET_ZA
+SkyNet Worldwide Express,SKYNETWORLDWIDE
+SkyNet Worldwide Express UAE,SKYNETWORLDWIDE_UAE
+Skynet Worldwide Express UK,SKYNETWORLDWIDE_UK
+Asendia HK – Premium Service (LATAM),SKYPOSTAL
+Smooth Couriers,SMOOTH
+SMSA Express,SMSA_EXPRESS
+Correos de España,SPAIN_CORREOS_ES
+Spanish Seur,SPANISH_SEUR
+Specialised Freight,SPECIALISEDFREIGHT_ZA
+Speed Couriers,SPEEDCOURIERS_GR
+Speedex Courier,SPEEDEXCOURIER
+SPOTON Logistics Pvt Ltd,SPOTON
+SRE Korea,SREKOREA
+StarTrack,STAR_TRACK
+Star Track Courier,STAR_TRACK_COURIER
+Star Track Express,STAR_TRACK_EXPRESS
+STO Express,STO
+PostNord Sweden,SWEDEN_POSTEN
+Swiss Post,SWISS_POST
+Sunyou Post,SYPOST
+DPEX China,SZDPEX
+Taiwan Post,TAIWAN_POST
+TAQBIN Hong Kong,TAQBIN_HK
+Yamato Japan,TAQBIN_JP
+TAQBIN Malaysia,TAQBIN_MY
+TAQBIN Singapore,TAQBIN_SG
+Geniki Taxydromiki,TAXYDROMIKI
+TCS,TCS
+Kerry Express Hong Kong,TGX
+Thailand Thai Post,THAILAND_POST
+The Courier Guy,THECOURIERGUY
+Tiki,TIKI
+TIPSA,TIPSA
+TNT,TNT
+TNT Australia,TNT_AU
+TNT-Click Italy,TNT_CLICK
+TNT France,TNT_FR
+TNT Italy,TNT_IT
+TNT Reference,TNT_REFERENCE
+TNT UK,TNT_UK
+TNT UK Reference,TNT_UK_REFERENCE
+Nexive (TNT Post Italy),TNTPOST_IT
+Toll IPEC,TOLL_IPEC
+Toll Priority,TOLL_PRIORITY
+Tolos,TOLOS
+Tophatter Express,TOPHATTEREXPRESS
+TrakPak,TRAKPAK
+Trans Kargo Internasional,TRANS_KARGO
+TransMission,TRANSMISSION_NL
+Tuffnells Parcels Express,TUFFNELLS
+UBI Smart Parcel,UBI_LOGISTICS
+United Delivery Service,UDS
+UK Mail,UK_MAIL
+UkrPoshta,UKRPOSHTA
+UPS,UPS
+UPS Freight,UPS_FREIGHT
+UPS Mail Innovations,UPS_MI
+USF Reddaway,USF_REDDAWAY
+USPS,USPS
+USPS Informed Visibility - Webhook,USPS_WEBHOOK
+ViettelPost,VIETTELPOST
+Vietnam Post,VNPOST
+Vietnam Post EMS,VNPOST_EMS
+Wahana,WAHANA
+WanbExpress,WANBEXPRESS
+Watkins Shepard,WATKINS_SHEPARD
+WeDo Logistics,WEDO
+WePost Logistics,WEPOST
+Whistl,WHISTL
+Wise Express,WISE_EXPRESS
+Wiseloads,WISELOADS
+WishPost,WISHPOST
+WMG Delivery,WMG
+wnDirect,WNDIRECT
+XDP Express,XDP_UK
+XDP Express Reference,XDP_UK_REFERENCE
+Xend Express,XEND
+XL Express,XL_EXPRESS
+Xpost.ph,XPOST
+XpressBees,XPRESSBEES
+XQ Express,XQ_EXPRESS
+Yakit,YAKIT
+Yanwen,YANWEN
+Yodel Domestic,YODEL
+Yodel International,YODEL_INTERNATIONAL
+YRC,YRC
+YTO Express,YTO
+Yunda Express,YUNDAEX
+Yun Express,YUNEXPRESS
+ZeptoExpress,ZEPTO_EXPRESS
+Zinc,ZINC
+ZJS International,ZJS_EXPRESS
+ZTO Express,ZTO_EXPRESS
+Zyllem,ZYLLEM


### PR DESCRIPTION
When tracking numbers are added for a Magento shipment that was paid for using Amazon Pay, pass the tracking details (carrier, tracking number) back to a new Amazon API when enabled in the admin. This data will be used to provide tracking updates to Alexa, and provide audio notification that a package has been delivered.

The AmazonPayV2 SDK requires patches to make it compatible with M1 (which doesn't use composer). For reference, here's the patch commit for future upgrades:

https://github.com/amzn/amazon-payments-magento-plugin/commit/5826baf63126f8225f7865a2b579c9df4ec2b82b
