### PR TITLE
Fix ArgumentCountError exceptions

### DIFF
--- a/lib/OffAmazonPaymentsService/Model/ConfirmOrderReferenceRequest.php
+++ b/lib/OffAmazonPaymentsService/Model/ConfirmOrderReferenceRequest.php
@@ -79,7 +79,7 @@ class OffAmazonPaymentsService_Model_ConfirmOrderReferenceRequest extends OffAma
      * @param string URL
      * @return this instance
      */
-    public function getSuccessUrl($value)
+    public function getSuccessUrl()
     {
         return $this->_fields['SuccessUrl']['FieldValue'];
     }
@@ -112,7 +112,7 @@ class OffAmazonPaymentsService_Model_ConfirmOrderReferenceRequest extends OffAma
      * @param string URL
      * @return this instance
      */
-    public function getFailureUrl($value)
+    public function getFailureUrl()
     {
         return $this->_fields['FailureUrl']['FieldValue'];
     }


### PR DESCRIPTION
*Issue #, if available:*
#381 

*Description of changes:*
- Removed unused `$value` parameters to `getSuccessUrl()` and `getFailureUrl()` to fix `Uncaught ArgumentCountError: Too few arguments to function.`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
